### PR TITLE
Drop messages in case of no connection

### DIFF
--- a/testscommon/websocketConnectionStub.go
+++ b/testscommon/websocketConnectionStub.go
@@ -5,8 +5,18 @@ type WebsocketConnectionStub struct {
 	OpenConnectionCalled func(url string) error
 	ReadMessageCalled    func() (messageType int, payload []byte, err error)
 	WriteMessageCalled   func(messageType int, data []byte) error
+	IsOpenCalled         func() bool
 	GetIDCalled          func() string
 	CloseCalled          func() error
+}
+
+// IsOpen --
+func (w *WebsocketConnectionStub) IsOpen() bool {
+	if w.IsOpenCalled != nil {
+		return w.IsOpenCalled()
+	}
+
+	return false
 }
 
 // OpenConnection -

--- a/websocket/client/client_test.go
+++ b/websocket/client/client_test.go
@@ -63,7 +63,7 @@ func TestNewWebSocketServer(t *testing.T) {
 
 func TestClient_SendAndClose(t *testing.T) {
 	args := createArgs()
-	args.BlockingSendIfNoConnection = true
+	args.DropMessagesIfNoConnection = false
 	ws, err := NewWebSocketClient(args)
 	require.Nil(t, err)
 
@@ -85,7 +85,7 @@ func TestClient_SendAndClose(t *testing.T) {
 
 func TestClient_Send(t *testing.T) {
 	args := createArgs()
-	args.BlockingSendIfNoConnection = true
+	args.DropMessagesIfNoConnection = false
 	ws, err := NewWebSocketClient(args)
 	require.Nil(t, err)
 
@@ -107,9 +107,9 @@ func TestClient_Send(t *testing.T) {
 	require.Equal(t, uint64(1), atomic.LoadUint64(&count))
 }
 
-func TestClient_ShouldSkipSend(t *testing.T) {
+func TestClient_DropMessageIfNoConnection(t *testing.T) {
 	args := createArgs()
-	args.BlockingSendIfNoConnection = false
+	args.DropMessagesIfNoConnection = true
 	ws, err := NewWebSocketClient(args)
 	require.Nil(t, err)
 

--- a/websocket/client/client_test.go
+++ b/websocket/client/client_test.go
@@ -63,6 +63,7 @@ func TestNewWebSocketServer(t *testing.T) {
 
 func TestClient_SendAndClose(t *testing.T) {
 	args := createArgs()
+	args.BlockingSendIfNoConnection = true
 	ws, err := NewWebSocketClient(args)
 	require.Nil(t, err)
 
@@ -84,6 +85,7 @@ func TestClient_SendAndClose(t *testing.T) {
 
 func TestClient_Send(t *testing.T) {
 	args := createArgs()
+	args.BlockingSendIfNoConnection = true
 	ws, err := NewWebSocketClient(args)
 	require.Nil(t, err)
 
@@ -103,4 +105,18 @@ func TestClient_Send(t *testing.T) {
 	wg.Wait()
 
 	require.Equal(t, uint64(1), atomic.LoadUint64(&count))
+}
+
+func TestClient_ShouldSkipSend(t *testing.T) {
+	args := createArgs()
+	args.BlockingSendIfNoConnection = false
+	ws, err := NewWebSocketClient(args)
+	require.Nil(t, err)
+
+	defer func() {
+		_ = ws.Close()
+	}()
+
+	err = ws.Send([]byte("test"), "test")
+	require.Nil(t, err)
 }

--- a/websocket/connection/wsConnClient.go
+++ b/websocket/connection/wsConnClient.go
@@ -72,6 +72,14 @@ func (wsc *wsConnClient) WriteMessage(messageType int, payload []byte) error {
 	return wsc.conn.WriteMessage(messageType, payload)
 }
 
+// IsOpen will return true if the connection is open
+func (wsc *wsConnClient) IsOpen() bool {
+	wsc.mut.RLock()
+	defer wsc.mut.RUnlock()
+
+	return wsc.conn != nil
+}
+
 func (wsc *wsConnClient) getConn() (*websocket.Conn, error) {
 	wsc.mut.RLock()
 	defer wsc.mut.RUnlock()

--- a/websocket/connection/wsConnClient_test.go
+++ b/websocket/connection/wsConnClient_test.go
@@ -161,3 +161,18 @@ func TestWsConnClient_ReOpenAlreadyOpenedConnectionShouldError(t *testing.T) {
 
 	_ = conClient.Close()
 }
+
+func TestWsConnClient_IsOpen(t *testing.T) {
+	testServer := testscommon.NewHttpTestEchoHandler()
+	defer testServer.Close()
+
+	conClient := NewWSConnClient()
+	connectionURL := createConnectionURLForTestServer(testServer)
+	err := conClient.OpenConnection(connectionURL)
+	require.Nil(t, err)
+
+	open := conClient.IsOpen()
+	require.True(t, open)
+
+	_ = conClient.Close()
+}

--- a/websocket/data/errors.go
+++ b/websocket/data/errors.go
@@ -31,3 +31,6 @@ var ErrExpectedAckWasNotReceivedOnClose = errors.New("expected ack message was n
 
 // ErrInvalidWebSocketHostMode signals that the provided mode is invalid
 var ErrInvalidWebSocketHostMode = errors.New("invalid web socket host mode")
+
+// ErrNoClientsConnected is an error signal indicating the absence of any connected clients
+var ErrNoClientsConnected = errors.New("no client connected")

--- a/websocket/data/operations.go
+++ b/websocket/data/operations.go
@@ -11,9 +11,10 @@ const (
 
 // WebSocketConfig holds the configuration needed for instantiating a new web socket server
 type WebSocketConfig struct {
-	URL                string
-	Mode               string
-	RetryDurationInSec int
-	WithAcknowledge    bool
-	BlockingAckOnError bool
+	URL                        string
+	Mode                       string
+	RetryDurationInSec         int
+	WithAcknowledge            bool
+	BlockingAckOnError         bool
+	BlockingSendIfNoConnection bool
 }

--- a/websocket/data/operations.go
+++ b/websocket/data/operations.go
@@ -16,5 +16,5 @@ type WebSocketConfig struct {
 	RetryDurationInSec         int
 	WithAcknowledge            bool
 	BlockingAckOnError         bool
-	BlockingSendIfNoConnection bool
+	DropMessagesIfNoConnection bool
 }

--- a/websocket/factory/factoryHost.go
+++ b/websocket/factory/factoryHost.go
@@ -35,12 +35,13 @@ func createWebSocketClient(args ArgsWebSocketHost) (FullDuplexHost, error) {
 	}
 
 	return client.NewWebSocketClient(client.ArgsWebSocketClient{
-		RetryDurationInSeconds: args.WebSocketConfig.RetryDurationInSec,
-		WithAcknowledge:        args.WebSocketConfig.WithAcknowledge,
-		URL:                    args.WebSocketConfig.URL,
-		PayloadConverter:       payloadConverter,
-		Log:                    args.Log,
-		BlockingAckOnError:     args.WebSocketConfig.BlockingAckOnError,
+		RetryDurationInSeconds:     args.WebSocketConfig.RetryDurationInSec,
+		WithAcknowledge:            args.WebSocketConfig.WithAcknowledge,
+		URL:                        args.WebSocketConfig.URL,
+		PayloadConverter:           payloadConverter,
+		Log:                        args.Log,
+		BlockingAckOnError:         args.WebSocketConfig.BlockingAckOnError,
+		BlockingSendIfNoConnection: args.WebSocketConfig.BlockingSendIfNoConnection,
 	})
 }
 
@@ -51,12 +52,13 @@ func createWebSocketServer(args ArgsWebSocketHost) (FullDuplexHost, error) {
 	}
 
 	host, err := server.NewWebSocketServer(server.ArgsWebSocketServer{
-		RetryDurationInSeconds: args.WebSocketConfig.RetryDurationInSec,
-		WithAcknowledge:        args.WebSocketConfig.WithAcknowledge,
-		URL:                    args.WebSocketConfig.URL,
-		PayloadConverter:       payloadConverter,
-		Log:                    args.Log,
-		BlockingAckOnError:     args.WebSocketConfig.BlockingAckOnError,
+		RetryDurationInSeconds:     args.WebSocketConfig.RetryDurationInSec,
+		WithAcknowledge:            args.WebSocketConfig.WithAcknowledge,
+		URL:                        args.WebSocketConfig.URL,
+		PayloadConverter:           payloadConverter,
+		Log:                        args.Log,
+		BlockingAckOnError:         args.WebSocketConfig.BlockingAckOnError,
+		BlockingSendIfNoConnection: args.WebSocketConfig.BlockingSendIfNoConnection,
 	})
 	if err != nil {
 		return nil, err

--- a/websocket/factory/factoryHost.go
+++ b/websocket/factory/factoryHost.go
@@ -41,7 +41,7 @@ func createWebSocketClient(args ArgsWebSocketHost) (FullDuplexHost, error) {
 		PayloadConverter:           payloadConverter,
 		Log:                        args.Log,
 		BlockingAckOnError:         args.WebSocketConfig.BlockingAckOnError,
-		BlockingSendIfNoConnection: args.WebSocketConfig.BlockingSendIfNoConnection,
+		DropMessagesIfNoConnection: args.WebSocketConfig.DropMessagesIfNoConnection,
 	})
 }
 
@@ -58,7 +58,7 @@ func createWebSocketServer(args ArgsWebSocketHost) (FullDuplexHost, error) {
 		PayloadConverter:           payloadConverter,
 		Log:                        args.Log,
 		BlockingAckOnError:         args.WebSocketConfig.BlockingAckOnError,
-		BlockingSendIfNoConnection: args.WebSocketConfig.BlockingSendIfNoConnection,
+		DropMessagesIfNoConnection: args.WebSocketConfig.DropMessagesIfNoConnection,
 	})
 	if err != nil {
 		return nil, err

--- a/websocket/integrationTests/testInitializer.go
+++ b/websocket/integrationTests/testInitializer.go
@@ -21,21 +21,23 @@ var (
 
 func createClient(url string, log core.Logger) (hostFactory.FullDuplexHost, error) {
 	return client.NewWebSocketClient(client.ArgsWebSocketClient{
-		RetryDurationInSeconds: retryDurationInSeconds,
-		WithAcknowledge:        true,
-		URL:                    url,
-		PayloadConverter:       payloadConverter,
-		Log:                    log,
+		RetryDurationInSeconds:     retryDurationInSeconds,
+		WithAcknowledge:            true,
+		URL:                        url,
+		PayloadConverter:           payloadConverter,
+		Log:                        log,
+		BlockingSendIfNoConnection: true,
 	})
 }
 
 func createServer(url string, log core.Logger) (hostFactory.FullDuplexHost, error) {
 	return server.NewWebSocketServer(server.ArgsWebSocketServer{
-		RetryDurationInSeconds: retryDurationInSeconds,
-		WithAcknowledge:        true,
-		URL:                    url,
-		PayloadConverter:       payloadConverter,
-		Log:                    log,
+		RetryDurationInSeconds:     retryDurationInSeconds,
+		WithAcknowledge:            true,
+		URL:                        url,
+		PayloadConverter:           payloadConverter,
+		Log:                        log,
+		BlockingSendIfNoConnection: true,
 	})
 }
 

--- a/websocket/integrationTests/testInitializer.go
+++ b/websocket/integrationTests/testInitializer.go
@@ -26,7 +26,7 @@ func createClient(url string, log core.Logger) (hostFactory.FullDuplexHost, erro
 		URL:                        url,
 		PayloadConverter:           payloadConverter,
 		Log:                        log,
-		BlockingSendIfNoConnection: true,
+		DropMessagesIfNoConnection: false,
 	})
 }
 
@@ -37,7 +37,7 @@ func createServer(url string, log core.Logger) (hostFactory.FullDuplexHost, erro
 		URL:                        url,
 		PayloadConverter:           payloadConverter,
 		Log:                        log,
-		BlockingSendIfNoConnection: true,
+		DropMessagesIfNoConnection: false,
 	})
 }
 

--- a/websocket/interface.go
+++ b/websocket/interface.go
@@ -25,6 +25,7 @@ type PayloadConverter interface {
 type WSConClient interface {
 	io.Closer
 	OpenConnection(url string) error
+	IsOpen() bool
 	WriteMessage(messageType int, data []byte) error
 	ReadMessage() (int, []byte, error)
 	GetID() string

--- a/websocket/server/server.go
+++ b/websocket/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -148,13 +147,9 @@ func (s *server) initializeServer(wsURL string, wsPath string) {
 // Send will send the provided payload from args
 func (s *server) Send(payload []byte, topic string) error {
 	transceiversAndCon := s.transceiversAndConn.getAll()
-	noConnection := len(transceiversAndCon) == 0
-	dropMessage := noConnection && s.dropMessagesIfNoConnection
-	if dropMessage {
-		return nil
-	}
-	if noConnection {
-		return errors.New("cannot send message: no clients connected")
+	noClients := len(transceiversAndCon) == 0
+	if noClients && !s.dropMessagesIfNoConnection {
+		return data.ErrNoClientsConnected
 	}
 
 	for _, tuple := range transceiversAndCon {

--- a/websocket/server/server_test.go
+++ b/websocket/server/server_test.go
@@ -109,9 +109,9 @@ func TestServer_ListenAndRegisterPayloadHandlerAndClose(t *testing.T) {
 	wg.Wait()
 }
 
-func TestServer_SkipSendInCaseOfNoConnection(t *testing.T) {
+func TestServer_DropMessageInCaseOfNoConnection(t *testing.T) {
 	args := createArgs()
-	args.BlockingSendIfNoConnection = false
+	args.DropMessagesIfNoConnection = true
 	args.URL = "localhost:9211"
 	wsServer, _ := NewWebSocketServer(args)
 
@@ -123,9 +123,9 @@ func TestServer_SkipSendInCaseOfNoConnection(t *testing.T) {
 	require.Nil(t, err)
 }
 
-func TestServer_SendErrorIfNoConnection(t *testing.T) {
+func TestServer_SendReturnsErrorIfNoConnection(t *testing.T) {
 	args := createArgs()
-	args.BlockingSendIfNoConnection = true
+	args.DropMessagesIfNoConnection = false
 	args.URL = "localhost:9211"
 	wsServer, _ := NewWebSocketServer(args)
 

--- a/websocket/server/server_test.go
+++ b/websocket/server/server_test.go
@@ -134,5 +134,5 @@ func TestServer_SendReturnsErrorIfNoConnection(t *testing.T) {
 	}()
 
 	err := wsServer.Send([]byte("test"), "test")
-	require.Equal(t, "cannot send message: no clients connected", err.Error())
+	require.Equal(t, data.ErrNoClientsConnected, err)
 }

--- a/websocket/server/server_test.go
+++ b/websocket/server/server_test.go
@@ -108,3 +108,31 @@ func TestServer_ListenAndRegisterPayloadHandlerAndClose(t *testing.T) {
 	_ = wsServer.Close()
 	wg.Wait()
 }
+
+func TestServer_SkipSendInCaseOfNoConnection(t *testing.T) {
+	args := createArgs()
+	args.BlockingSendIfNoConnection = false
+	args.URL = "localhost:9211"
+	wsServer, _ := NewWebSocketServer(args)
+
+	defer func() {
+		_ = wsServer.Close()
+	}()
+
+	err := wsServer.Send([]byte("test"), "test")
+	require.Nil(t, err)
+}
+
+func TestServer_SendErrorIfNoConnection(t *testing.T) {
+	args := createArgs()
+	args.BlockingSendIfNoConnection = true
+	args.URL = "localhost:9211"
+	wsServer, _ := NewWebSocketServer(args)
+
+	defer func() {
+		_ = wsServer.Close()
+	}()
+
+	err := wsServer.Send([]byte("test"), "test")
+	require.Equal(t, "cannot send message: no clients connected", err.Error())
+}


### PR DESCRIPTION
- The implemented mechanism incorporates a feature that allows the skipping of message sending when there is no established connection with a client or a server. When such a connection is absent, the behavior of the system depends on a configurable flag. If the flag is set to false, the messages will be silently discarded without any indication. However, if the flag is set to true, indicating a preference for error notifications, the send method will return an error when attempting to send messages in the absence of a connection. This mechanism offers flexibility and control over how the system handles message delivery in different connectivity scenarios.
