### PR TITLE
Factory create payload handler

### DIFF
--- a/testscommon/creator/payloadHandlerCreatorStub.go
+++ b/testscommon/creator/payloadHandlerCreatorStub.go
@@ -1,0 +1,21 @@
+package creator
+
+import "github.com/multiversx/mx-chain-communication-go/websocket"
+
+// PayloadHandlerCreatorStub -
+type PayloadHandlerCreatorStub struct {
+	CreateCalled func() (websocket.PayloadHandler, error)
+}
+
+// Create -
+func (pcs *PayloadHandlerCreatorStub) Create() (websocket.PayloadHandler, error) {
+	if pcs.CreateCalled != nil {
+		return pcs.CreateCalled()
+	}
+	return nil, nil
+}
+
+// IsInterfaceNil -
+func (pcs *PayloadHandlerCreatorStub) IsInterfaceNil() bool {
+	return pcs == nil
+}

--- a/websocket/client/client.go
+++ b/websocket/client/client.go
@@ -139,8 +139,17 @@ func (c *client) Send(payload []byte, topic string) error {
 	return c.transceiver.Send(payload, topic, c.wsConn)
 }
 
-// SetPayloadHandler set the payload handler
-func (c *client) SetPayloadHandler(handler websocket.PayloadHandler) error {
+// SetPayloadHandlerCreator set the payload handler creator and create a new instance of PayloadHandler
+func (c *client) SetPayloadHandlerCreator(creator websocket.PayloadHandlerCreator) error {
+	if check.IfNil(creator) {
+		return data.ErrNilPayloadHandlerCreator
+	}
+
+	handler, err := creator.Create()
+	if err != nil {
+		return err
+	}
+
 	return c.transceiver.SetPayloadHandler(handler)
 }
 

--- a/websocket/data/errors.go
+++ b/websocket/data/errors.go
@@ -34,3 +34,6 @@ var ErrInvalidWebSocketHostMode = errors.New("invalid web socket host mode")
 
 // ErrNoClientsConnected is an error signal indicating the absence of any connected clients
 var ErrNoClientsConnected = errors.New("no client connected")
+
+// ErrNilPayloadHandlerCreator signals that a nil payload handler creator has been provided
+var ErrNilPayloadHandlerCreator = errors.New("nil payload handler creator provided")

--- a/websocket/examples/sendreceive/client/main.go
+++ b/websocket/examples/sendreceive/client/main.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 
 	"github.com/multiversx/mx-chain-communication-go/testscommon"
+	"github.com/multiversx/mx-chain-communication-go/testscommon/creator"
+	"github.com/multiversx/mx-chain-communication-go/websocket"
 	"github.com/multiversx/mx-chain-communication-go/websocket/data"
 	factoryHost "github.com/multiversx/mx-chain-communication-go/websocket/factory"
 	"github.com/multiversx/mx-chain-core-go/marshal/factory"
@@ -42,11 +44,16 @@ func main() {
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	_ = wsClient.SetPayloadHandler(&testscommon.PayloadHandlerStub{
-		ProcessPayloadCalled: func(payload []byte, topic string) error {
-			log.Info("received", "topic", topic, "payload", string(payload))
-			wg.Done()
-			return nil
+
+	_ = wsClient.SetPayloadHandlerCreator(&creator.PayloadHandlerCreatorStub{
+		CreateCalled: func() (websocket.PayloadHandler, error) {
+			return &testscommon.PayloadHandlerStub{
+				ProcessPayloadCalled: func(payload []byte, topic string) error {
+					log.Info("received", "topic", topic, "payload", string(payload))
+					wg.Done()
+					return nil
+				},
+			}, nil
 		},
 	})
 

--- a/websocket/factory/interface.go
+++ b/websocket/factory/interface.go
@@ -1,11 +1,11 @@
 package factory
 
-import "github.com/multiversx/mx-chain-communication-go/websocket"
+import webSocket "github.com/multiversx/mx-chain-communication-go/websocket"
 
 // FullDuplexHost defines what a full duplex host should be able to do
 type FullDuplexHost interface {
 	Send(payload []byte, topic string) error
-	SetPayloadHandler(handler websocket.PayloadHandler) error
+	SetPayloadHandlerCreator(creator webSocket.PayloadHandlerCreator) error
 	Close() error
 	IsInterfaceNil() bool
 }

--- a/websocket/interface.go
+++ b/websocket/interface.go
@@ -37,3 +37,9 @@ type HttpServerHandler interface {
 	ListenAndServe() error
 	Shutdown(ctx context.Context) error
 }
+
+// PayloadHandlerCreator dines what a payload handler creator should be able to do
+type PayloadHandlerCreator interface {
+	Create() (PayloadHandler, error)
+	IsInterfaceNil() bool
+}

--- a/websocket/nilPayloadHandlerCreator.go
+++ b/websocket/nilPayloadHandlerCreator.go
@@ -1,0 +1,17 @@
+package websocket
+
+type nilPayloadHandlerCreator struct{}
+
+func NewNilPayloadHandlerCreator() *nilPayloadHandlerCreator {
+	return new(nilPayloadHandlerCreator)
+}
+
+// Create will create a new instance of nilPayloadHandler
+func (phc *nilPayloadHandlerCreator) Create() (PayloadHandler, error) {
+	return NewNilPayloadHandler(), nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (phc *nilPayloadHandlerCreator) IsInterfaceNil() bool {
+	return phc == nil
+}

--- a/websocket/server/server_test.go
+++ b/websocket/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-communication-go/testscommon"
+	"github.com/multiversx/mx-chain-communication-go/testscommon/creator"
 	"github.com/multiversx/mx-chain-communication-go/websocket"
 	"github.com/multiversx/mx-chain-communication-go/websocket/data"
 	"github.com/stretchr/testify/require"
@@ -98,7 +99,7 @@ func TestServer_ListenAndRegisterPayloadHandlerAndClose(t *testing.T) {
 	args.URL = "localhost:9211"
 	wsServer, _ := NewWebSocketServer(args)
 
-	_ = wsServer.SetPayloadHandler(&testscommon.PayloadHandlerStub{})
+	_ = wsServer.SetPayloadHandlerCreator(&creator.PayloadHandlerCreatorStub{})
 	wsServer.connectionHandler(&testscommon.WebsocketConnectionStub{
 		ReadMessageCalled: func() (messageType int, payload []byte, err error) {
 			return 0, nil, errors.New("local error")


### PR DESCRIPTION
- In the code modification, the method `SetPayloadHandler(...)` has been removed and replaced with a new method that sets a factory for creating instances of the PayloadHandler. This change is necessary when there is a requirement to have multiple instances of the `PayloadHandler` for each client connected to the WebSocket host.
- The previous implementation had a single method, `SetPayloadHandler(...)`, which allowed setting a single instance of the `PayloadHandler` for all clients. However, in certain scenarios, it may be necessary to have a separate `PayloadHandler` instance for each connected client.