### PR TITLE
Changes for multiple messengers

### DIFF
--- a/p2p/config/config.go
+++ b/p2p/config/config.go
@@ -5,6 +5,7 @@ type P2PConfig struct {
 	Node                NodeConfig
 	KadDhtPeerDiscovery KadDhtPeerDiscoveryConfig
 	Sharding            ShardingConfig
+	Logger              LoggerConfig
 }
 
 // NodeConfig will hold basic p2p settings
@@ -35,11 +36,9 @@ type ShardingConfig struct {
 	MaxCrossShardObservers  uint32
 	MaxSeeders              uint32
 	Type                    string
-	AdditionalConnections   AdditionalConnectionsConfig
 }
 
-// AdditionalConnectionsConfig will hold the additional connections that will be open when certain conditions are met
-// All these values should be added to the maximum target peer count value
-type AdditionalConnectionsConfig struct {
-	MaxFullHistoryObservers uint32
+// LoggerConfig will hold the logger configuration
+type LoggerConfig struct {
+	Prefix string
 }

--- a/p2p/config/config.go
+++ b/p2p/config/config.go
@@ -14,7 +14,6 @@ type NodeConfig struct {
 	MaximumExpectedPeerCount        uint64
 	ThresholdMinConnectedPeers      uint32
 	MinNumPeersToWaitForOnBootstrap uint32
-	MessengerType                   string
 }
 
 // KadDhtPeerDiscoveryConfig will hold the kad-dht discovery config settings

--- a/p2p/config/config.go
+++ b/p2p/config/config.go
@@ -14,6 +14,7 @@ type NodeConfig struct {
 	MaximumExpectedPeerCount        uint64
 	ThresholdMinConnectedPeers      uint32
 	MinNumPeersToWaitForOnBootstrap uint32
+	MessengerType                   string
 }
 
 // KadDhtPeerDiscoveryConfig will hold the kad-dht discovery config settings

--- a/p2p/constants.go
+++ b/p2p/constants.go
@@ -2,15 +2,6 @@ package p2p
 
 import "time"
 
-// NodeOperation defines the p2p node operation
-type NodeOperation string
-
-// NormalOperation defines the normal mode operation: either seeder, observer or validator
-const NormalOperation NodeOperation = "normal operation"
-
-// FullArchiveMode defines the node operation as a full archive mode
-const FullArchiveMode NodeOperation = "full archive mode"
-
 const (
 	displayLastPidChars = 12
 

--- a/p2p/debug/p2pDebugger.go
+++ b/p2p/debug/p2pDebugger.go
@@ -12,9 +12,12 @@ import (
 	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
-var log = logger.GetOrCreate("debug/p2p")
+const (
+	printInterval = time.Second
+	loggerName    = "debug/p2p"
+)
 
-const printInterval = time.Second
+var log = logger.GetOrCreate(loggerName)
 
 type metric struct {
 	topic string
@@ -62,7 +65,11 @@ type p2pDebugger struct {
 }
 
 // NewP2PDebugger creates a new p2p debug instance
-func NewP2PDebugger(selfPeerId core.PeerID) *p2pDebugger {
+func NewP2PDebugger(selfPeerId core.PeerID, loggerPrefix string) *p2pDebugger {
+	if len(loggerPrefix) > 0 {
+		log = logger.GetOrCreate(loggerPrefix + loggerName)
+	}
+
 	pd := &p2pDebugger{
 		selfPeerId: selfPeerId,
 		data:       make(map[string]*metric),

--- a/p2p/debug/p2pDebugger_test.go
+++ b/p2p/debug/p2pDebugger_test.go
@@ -23,7 +23,7 @@ func shouldNotCompute() bool {
 func TestNewP2PDebugger(t *testing.T) {
 	t.Parallel()
 
-	pd := NewP2PDebugger("")
+	pd := NewP2PDebugger("", "")
 
 	assert.False(t, check.IfNil(pd))
 }

--- a/p2p/integrationTests/peerDisconnecting/peerDisconnecting_test.go
+++ b/p2p/integrationTests/peerDisconnecting/peerDisconnecting_test.go
@@ -41,9 +41,6 @@ func TestPeerDisconnectionWithOneAdvertiserWithShardingWithLists(t *testing.T) {
 		MaxCrossShardObservers:  1,
 		MaxSeeders:              1,
 		Type:                    p2p.ListsSharder,
-		AdditionalConnections: config.AdditionalConnectionsConfig{
-			MaxFullHistoryObservers: 1,
-		},
 	}
 	p2pCfg.Node.ThresholdMinConnectedPeers = 3
 
@@ -63,7 +60,6 @@ func testPeerDisconnectionWithOneAdvertiser(t *testing.T, p2pConfig config.P2PCo
 		ListenAddress:         libp2p.TestListenAddrWithIp4AndTcp,
 		P2pConfig:             p2pConfigSeeder,
 		PreferredPeersHolder:  &mock.PeersHolderStub{},
-		NodeOperationMode:     p2p.NormalOperation,
 		Marshaller:            &testscommon.MarshallerMock{},
 		SyncTimer:             &mock.SyncTimerStub{},
 		PeersRatingHandler:    &mock.PeersRatingHandlerStub{},
@@ -85,7 +81,6 @@ func testPeerDisconnectionWithOneAdvertiser(t *testing.T, p2pConfig config.P2PCo
 			ListenAddress:         libp2p.TestListenAddrWithIp4AndTcp,
 			P2pConfig:             p2pConfig,
 			PreferredPeersHolder:  &mock.PeersHolderStub{},
-			NodeOperationMode:     p2p.NormalOperation,
 			Marshaller:            &testscommon.MarshallerMock{},
 			SyncTimer:             &mock.SyncTimerStub{},
 			PeersRatingHandler:    &mock.PeersRatingHandlerStub{},

--- a/p2p/integrationTests/peerDisconnecting/seedersDisconnecting_test.go
+++ b/p2p/integrationTests/peerDisconnecting/seedersDisconnecting_test.go
@@ -34,9 +34,6 @@ func TestSeedersDisconnectionWith2AdvertiserAnd3Peers(t *testing.T) {
 		MaxCrossShardObservers:  1,
 		MaxSeeders:              3,
 		Type:                    p2p.ListsSharder,
-		AdditionalConnections: config.AdditionalConnectionsConfig{
-			MaxFullHistoryObservers: 0,
-		},
 	}
 	p2pCfg.Node.ThresholdMinConnectedPeers = 3
 
@@ -53,7 +50,6 @@ func TestSeedersDisconnectionWith2AdvertiserAnd3Peers(t *testing.T) {
 			ListenAddress:         libp2p.TestListenAddrWithIp4AndTcp,
 			P2pConfig:             p2pCfg,
 			PreferredPeersHolder:  &mock.PeersHolderStub{},
-			NodeOperationMode:     p2p.NormalOperation,
 			Marshaller:            &testscommon.MarshallerMock{},
 			SyncTimer:             &mock.SyncTimerStub{},
 			PeersRatingHandler:    &mock.PeersRatingHandlerStub{},
@@ -131,7 +127,6 @@ func createBootstrappedSeeders(baseP2PConfig config.P2PConfig, numSeeders int, n
 		ListenAddress:         libp2p.TestListenAddrWithIp4AndTcp,
 		P2pConfig:             p2pConfigSeeder,
 		PreferredPeersHolder:  &mock.PeersHolderStub{},
-		NodeOperationMode:     p2p.NormalOperation,
 		Marshaller:            &testscommon.MarshallerMock{},
 		SyncTimer:             &mock.SyncTimerStub{},
 		PeersRatingHandler:    &mock.PeersRatingHandlerStub{},
@@ -152,7 +147,6 @@ func createBootstrappedSeeders(baseP2PConfig config.P2PConfig, numSeeders int, n
 			ListenAddress:         libp2p.TestListenAddrWithIp4AndTcp,
 			P2pConfig:             p2pConfigSeeder,
 			PreferredPeersHolder:  &mock.PeersHolderStub{},
-			NodeOperationMode:     p2p.NormalOperation,
 			Marshaller:            &testscommon.MarshallerMock{},
 			SyncTimer:             &mock.SyncTimerStub{},
 			PeersRatingHandler:    &mock.PeersRatingHandlerStub{},

--- a/p2p/integrationTests/testCommon.go
+++ b/p2p/integrationTests/testCommon.go
@@ -132,18 +132,12 @@ func CreateMessengerFromConfig(p2pConfig config.P2PConfig) p2p.Messenger {
 		P2pConfig:             p2pConfig,
 		SyncTimer:             &libp2p.LocalSyncTimer{},
 		PreferredPeersHolder:  &mock.PeersHolderStub{},
-		NodeOperationMode:     p2p.NormalOperation,
 		PeersRatingHandler:    &mock.PeersRatingHandlerStub{},
 		ConnectionWatcherType: p2p.ConnectionWatcherTypePrint,
 		P2pPrivateKey:         mock.NewPrivateKeyMock(),
 		P2pSingleSigner:       &mock.SingleSignerStub{},
 		P2pKeyGenerator:       &mock.KeyGenStub{},
 		MessengerType:         p2p.RegularMessenger,
-	}
-
-	if p2pConfig.Sharding.AdditionalConnections.MaxFullHistoryObservers > 0 {
-		// we deliberately set this, automatically choose full archive node mode
-		arg.NodeOperationMode = p2p.FullArchiveMode
 	}
 
 	libP2PMes, err := libp2p.NewNetworkMessenger(arg)

--- a/p2p/libp2p/connectionMonitor/libp2pConnectionMonitorSimple.go
+++ b/p2p/libp2p/connectionMonitor/libp2pConnectionMonitorSimple.go
@@ -15,12 +15,13 @@ import (
 	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
-var log = logger.GetOrCreate("p2p/libp2p/connectionmonitor")
-
 const (
 	durationBetweenReconnectAttempts = time.Second * 5
 	durationCheckConnections         = time.Second
+	loggerName                       = "p2p/libp2p/connectionmonitor"
 )
+
+var log = logger.GetOrCreate(loggerName)
 
 type libp2pConnectionMonitorSimple struct {
 	chDoReconnect              chan struct{}
@@ -43,6 +44,7 @@ type ArgsConnectionMonitorSimple struct {
 	PreferredPeersHolder       p2p.PreferredPeersHolderHandler
 	ConnectionsWatcher         p2p.ConnectionsWatcher
 	Network                    network.Network
+	LoggerPrefix               string
 }
 
 // NewLibp2pConnectionMonitorSimple creates a new connection monitor (version 2 that is more streamlined and does not care
@@ -52,6 +54,10 @@ func NewLibp2pConnectionMonitorSimple(args ArgsConnectionMonitorSimple) (*libp2p
 	err := checkArgs(args)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(args.LoggerPrefix) > 0 {
+		log = logger.GetOrCreate(args.LoggerPrefix + loggerName)
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/p2p/libp2p/crypto/identityGenerator.go
+++ b/p2p/libp2p/crypto/identityGenerator.go
@@ -10,13 +10,20 @@ import (
 )
 
 var emptyPrivateKeyBytes = []byte("")
-var log = logger.GetOrCreate("p2p/libp2p/crypto")
+
+const loggerName = "p2p/libp2p/crypto"
+
+var log = logger.GetOrCreate(loggerName)
 
 type identityGenerator struct {
 }
 
 // NewIdentityGenerator creates a new identity generator
-func NewIdentityGenerator() *identityGenerator {
+func NewIdentityGenerator(loggerPrefix string) *identityGenerator {
+	if len(loggerPrefix) > 0 {
+		log = logger.GetOrCreate(loggerPrefix + loggerName)
+	}
+
 	return &identityGenerator{}
 }
 

--- a/p2p/libp2p/crypto/identityGenerator_test.go
+++ b/p2p/libp2p/crypto/identityGenerator_test.go
@@ -14,14 +14,14 @@ import (
 func TestNewIdentityGenerator(t *testing.T) {
 	t.Parallel()
 
-	generator := crypto.NewIdentityGenerator()
+	generator := crypto.NewIdentityGenerator("")
 	assert.False(t, check.IfNil(generator))
 }
 
 func TestIdentityGenerator_CreateP2PPrivateKey(t *testing.T) {
 	t.Parallel()
 
-	generator := crypto.NewIdentityGenerator()
+	generator := crypto.NewIdentityGenerator("")
 
 	skKey1, _, errGenerate := libp2pCrypto.GenerateSecp256k1Key(rand.Reader)
 	require.Nil(t, errGenerate)
@@ -75,7 +75,7 @@ func TestIdentityGenerator_CreateP2PPrivateKey(t *testing.T) {
 func TestIdentityGenerator_CreateRandomP2PIdentity(t *testing.T) {
 	t.Parallel()
 
-	generator := crypto.NewIdentityGenerator()
+	generator := crypto.NewIdentityGenerator("")
 	sk1, pid1, err := generator.CreateRandomP2PIdentity()
 	assert.Nil(t, err)
 

--- a/p2p/libp2p/crypto/p2pKeyConverter_test.go
+++ b/p2p/libp2p/crypto/p2pKeyConverter_test.go
@@ -66,7 +66,7 @@ func TestConvertPublicKeyToPeerID(t *testing.T) {
 	t.Run("should work using a generated identity", func(t *testing.T) {
 		t.Parallel()
 
-		generator := p2pCrypto.NewIdentityGenerator()
+		generator := p2pCrypto.NewIdentityGenerator("")
 		skBytes, pid, err := generator.CreateRandomP2PIdentity()
 		assert.Nil(t, err)
 

--- a/p2p/libp2p/discovery/continuousKadDhtDiscoverer.go
+++ b/p2p/libp2p/discovery/continuousKadDhtDiscoverer.go
@@ -18,7 +18,9 @@ import (
 var _ p2p.PeerDiscoverer = (*ContinuousKadDhtDiscoverer)(nil)
 var _ p2p.Reconnecter = (*ContinuousKadDhtDiscoverer)(nil)
 
-var log = logger.GetOrCreate("p2p/libp2p/kaddht")
+const loggerName = "p2p/libp2p/kaddht"
+
+var log = logger.GetOrCreate(loggerName)
 
 const kadDhtName = "kad-dht discovery"
 
@@ -34,6 +36,7 @@ type ArgKadDht struct {
 	RoutingTableRefresh         time.Duration
 	KddSharder                  p2p.Sharder
 	ConnectionWatcher           p2p.ConnectionsWatcher
+	LoggerPrefix                string
 }
 
 // ContinuousKadDhtDiscoverer is the kad-dht discovery type implementation
@@ -58,6 +61,10 @@ type ContinuousKadDhtDiscoverer struct {
 // NewContinuousKadDhtDiscoverer creates a new kad-dht discovery type implementation
 // initialPeersList can be nil or empty, no initial connection will be attempted, a warning message will appear
 func NewContinuousKadDhtDiscoverer(arg ArgKadDht) (*ContinuousKadDhtDiscoverer, error) {
+	if len(arg.LoggerPrefix) > 0 {
+		log = logger.GetOrCreate(arg.LoggerPrefix + loggerName)
+	}
+
 	sharder, err := prepareArguments(arg)
 	if err != nil {
 		return nil, err

--- a/p2p/libp2p/discovery/factory/peerDiscovererFactory.go
+++ b/p2p/libp2p/discovery/factory/peerDiscovererFactory.go
@@ -14,8 +14,9 @@ import (
 const typeLegacy = "legacy"
 const typeOptimized = "optimized"
 const defaultSeedersReconnectionInterval = time.Minute * 5
+const loggerName = "p2p/discovery/factory"
 
-var log = logger.GetOrCreate("p2p/discovery/factory")
+var log = logger.GetOrCreate(loggerName)
 
 // ArgsPeerDiscoverer is the DTO struct used in the NewPeerDiscoverer function
 type ArgsPeerDiscoverer struct {
@@ -29,6 +30,10 @@ type ArgsPeerDiscoverer struct {
 // NewPeerDiscoverer generates an implementation of PeerDiscoverer by parsing the p2pConfig struct
 // Errors if config is badly formatted
 func NewPeerDiscoverer(args ArgsPeerDiscoverer) (p2p.PeerDiscoverer, error) {
+	if len(args.P2pConfig.Logger.Prefix) > 0 {
+		log = logger.GetOrCreate(args.P2pConfig.Logger.Prefix + loggerName)
+	}
+
 	if args.P2pConfig.KadDhtPeerDiscovery.Enabled {
 		return createKadDhtPeerDiscoverer(args)
 	}

--- a/p2p/libp2p/issues_test.go
+++ b/p2p/libp2p/issues_test.go
@@ -33,7 +33,6 @@ func createMessenger() p2p.Messenger {
 		},
 		SyncTimer:             &libp2p.LocalSyncTimer{},
 		PreferredPeersHolder:  &mock.PeersHolderStub{},
-		NodeOperationMode:     p2p.NormalOperation,
 		PeersRatingHandler:    &mock.PeersRatingHandlerStub{},
 		ConnectionWatcherType: p2p.ConnectionWatcherTypePrint,
 		P2pPrivateKey:         mock.NewPrivateKeyMock(),

--- a/p2p/libp2p/metrics/factory/connectionWatcherFactory.go
+++ b/p2p/libp2p/metrics/factory/connectionWatcherFactory.go
@@ -9,10 +9,10 @@ import (
 )
 
 // NewConnectionsWatcher creates a new ConnectionWatcher instance based on the input parameters
-func NewConnectionsWatcher(connectionsWatcherType string, timeToLive time.Duration) (p2p.ConnectionsWatcher, error) {
+func NewConnectionsWatcher(connectionsWatcherType string, timeToLive time.Duration, loggerPrefix string) (p2p.ConnectionsWatcher, error) {
 	switch connectionsWatcherType {
 	case p2p.ConnectionWatcherTypePrint:
-		return metrics.NewPrintConnectionsWatcher(timeToLive)
+		return metrics.NewPrintConnectionsWatcher(timeToLive, loggerPrefix)
 	case p2p.ConnectionWatcherTypeDisabled, p2p.ConnectionWatcherTypeEmpty:
 		return metrics.NewDisabledConnectionsWatcher(), nil
 	default:

--- a/p2p/libp2p/metrics/factory/connectionWatcherFactory_test.go
+++ b/p2p/libp2p/metrics/factory/connectionWatcherFactory_test.go
@@ -18,7 +18,7 @@ func TestNewConnectionsWatcher(t *testing.T) {
 	t.Run("print connections watcher", func(t *testing.T) {
 		t.Parallel()
 
-		cw, err := factory.NewConnectionsWatcher(p2p.ConnectionWatcherTypePrint, time.Second)
+		cw, err := factory.NewConnectionsWatcher(p2p.ConnectionWatcherTypePrint, time.Second, "")
 		assert.Nil(t, err)
 		assert.False(t, check.IfNil(cw))
 		assert.Equal(t, "*metrics.printConnectionsWatcher", fmt.Sprintf("%T", cw))
@@ -26,7 +26,7 @@ func TestNewConnectionsWatcher(t *testing.T) {
 	t.Run("disabled connections watcher", func(t *testing.T) {
 		t.Parallel()
 
-		cw, err := factory.NewConnectionsWatcher(p2p.ConnectionWatcherTypeDisabled, time.Second)
+		cw, err := factory.NewConnectionsWatcher(p2p.ConnectionWatcherTypeDisabled, time.Second, "")
 		assert.Nil(t, err)
 		assert.False(t, check.IfNil(cw))
 		assert.Equal(t, "*metrics.disabledConnectionsWatcher", fmt.Sprintf("%T", cw))
@@ -34,7 +34,7 @@ func TestNewConnectionsWatcher(t *testing.T) {
 	t.Run("empty connections watcher", func(t *testing.T) {
 		t.Parallel()
 
-		cw, err := factory.NewConnectionsWatcher(p2p.ConnectionWatcherTypeEmpty, time.Second)
+		cw, err := factory.NewConnectionsWatcher(p2p.ConnectionWatcherTypeEmpty, time.Second, "")
 		assert.Nil(t, err)
 		assert.False(t, check.IfNil(cw))
 		assert.Equal(t, "*metrics.disabledConnectionsWatcher", fmt.Sprintf("%T", cw))
@@ -42,7 +42,7 @@ func TestNewConnectionsWatcher(t *testing.T) {
 	t.Run("unknown type", func(t *testing.T) {
 		t.Parallel()
 
-		cw, err := factory.NewConnectionsWatcher("unknown", time.Second)
+		cw, err := factory.NewConnectionsWatcher("unknown", time.Second, "")
 		assert.True(t, errors.Is(err, factory.ErrUnknownConnectionWatcherType))
 		assert.True(t, check.IfNil(cw))
 	})

--- a/p2p/libp2p/metrics/printConnectionsWatcher.go
+++ b/p2p/libp2p/metrics/printConnectionsWatcher.go
@@ -13,9 +13,12 @@ import (
 	"github.com/multiversx/mx-chain-storage-go/types"
 )
 
-const minTimeToLive = time.Second
+const (
+	minTimeToLive = time.Second
+	loggerName    = "p2p/libp2p/metrics"
+)
 
-var log = logger.GetOrCreate("p2p/libp2p/metrics")
+var log = logger.GetOrCreate(loggerName)
 
 type printConnectionsWatcher struct {
 	timeCacher      types.TimeCacher
@@ -26,9 +29,13 @@ type printConnectionsWatcher struct {
 }
 
 // NewPrintConnectionsWatcher creates a new
-func NewPrintConnectionsWatcher(timeToLive time.Duration) (*printConnectionsWatcher, error) {
+func NewPrintConnectionsWatcher(timeToLive time.Duration, loggerPrefix string) (*printConnectionsWatcher, error) {
 	if timeToLive < minTimeToLive {
 		return nil, fmt.Errorf("%w in NewPrintConnectionsWatcher, got: %d, minimum: %d", ErrInvalidValueForTimeToLiveParam, timeToLive, minTimeToLive)
+	}
+
+	if len(loggerPrefix) > 0 {
+		log = logger.GetOrCreate(loggerPrefix + loggerName)
 	}
 
 	pcw := &printConnectionsWatcher{

--- a/p2p/libp2p/metrics/printConnectionsWatcher_test.go
+++ b/p2p/libp2p/metrics/printConnectionsWatcher_test.go
@@ -18,14 +18,14 @@ func TestNewPrintConnectionsWatcher(t *testing.T) {
 	t.Run("invalid value for time to live parameter should error", func(t *testing.T) {
 		t.Parallel()
 
-		pcw, err := metrics.NewPrintConnectionsWatcher(metrics.MinTimeToLive - time.Nanosecond)
+		pcw, err := metrics.NewPrintConnectionsWatcher(metrics.MinTimeToLive-time.Nanosecond, "")
 		assert.True(t, check.IfNil(pcw))
 		assert.True(t, errors.Is(err, metrics.ErrInvalidValueForTimeToLiveParam))
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		pcw, err := metrics.NewPrintConnectionsWatcher(metrics.MinTimeToLive)
+		pcw, err := metrics.NewPrintConnectionsWatcher(metrics.MinTimeToLive, "")
 		assert.False(t, check.IfNil(pcw))
 		assert.Nil(t, err)
 
@@ -39,7 +39,7 @@ func TestPrintConnectionsWatcher_Close(t *testing.T) {
 	t.Run("no iteration has been done", func(t *testing.T) {
 		t.Parallel()
 
-		pcw, _ := metrics.NewPrintConnectionsWatcher(time.Hour)
+		pcw, _ := metrics.NewPrintConnectionsWatcher(time.Hour, "")
 		err := pcw.Close()
 
 		assert.Nil(t, err)
@@ -49,7 +49,7 @@ func TestPrintConnectionsWatcher_Close(t *testing.T) {
 	t.Run("iterations were done", func(t *testing.T) {
 		t.Parallel()
 
-		pcw, _ := metrics.NewPrintConnectionsWatcher(time.Second)
+		pcw, _ := metrics.NewPrintConnectionsWatcher(time.Second, "")
 		time.Sleep(time.Second * 4)
 		err := pcw.Close()
 

--- a/p2p/libp2p/mockMessenger.go
+++ b/p2p/libp2p/mockMessenger.go
@@ -44,7 +44,7 @@ func NewMockMessenger(
 		ctx:        ctx,
 		cancelFunc: cancelFunc,
 	}
-	p2pNode.printConnectionsWatcher, err = factory.NewConnectionsWatcher(args.ConnectionWatcherType, ttlConnectionsWatcher)
+	p2pNode.printConnectionsWatcher, err = factory.NewConnectionsWatcher(args.ConnectionWatcherType, ttlConnectionsWatcher, "")
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/libp2p/networksharding/export_test.go
+++ b/p2p/libp2p/networksharding/export_test.go
@@ -48,11 +48,6 @@ func (ls *listsSharder) GetMaxSeeders() int {
 	return ls.maxSeeders
 }
 
-// GetMaxFullHistoryObservers -
-func (ls *listsSharder) GetMaxFullHistoryObservers() int {
-	return ls.maxFullHistoryObservers
-}
-
 // GetMaxUnknown -
 func (ls *listsSharder) GetMaxUnknown() int {
 	return ls.maxUnknown

--- a/p2p/libp2p/networksharding/factory/sharderFactory_test.go
+++ b/p2p/libp2p/networksharding/factory/sharderFactory_test.go
@@ -3,7 +3,6 @@ package factory_test
 import (
 	"errors"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/multiversx/mx-chain-communication-go/p2p"
@@ -29,26 +28,9 @@ func createMockArg() factory.ArgsSharderFactory {
 				MaxCrossShardValidators: 1,
 				MaxIntraShardObservers:  1,
 				MaxCrossShardObservers:  1,
-				AdditionalConnections: config.AdditionalConnectionsConfig{
-					MaxFullHistoryObservers: 1,
-				},
 			},
 		},
-		NodeOperationMode: p2p.NormalOperation,
 	}
-}
-
-func TestNewSharder_CreateListsSharderUnknownNodeOperationShouldError(t *testing.T) {
-	t.Parallel()
-
-	arg := createMockArg()
-	arg.P2pConfig.Sharding.Type = p2p.ListsSharder
-	arg.NodeOperationMode = ""
-	sharder, err := factory.NewSharder(arg)
-
-	assert.True(t, errors.Is(err, p2p.ErrInvalidValue))
-	assert.True(t, strings.Contains(err.Error(), "unknown node operation mode"))
-	assert.True(t, check.IfNil(sharder))
 }
 
 func TestNewSharder_CreateListsSharderShouldWork(t *testing.T) {

--- a/p2p/libp2p/networksharding/listsSharder.go
+++ b/p2p/libp2p/networksharding/listsSharder.go
@@ -31,9 +31,10 @@ const crossShardValidators = 20
 const crossShardObservers = 30
 const seeders = 40
 const unknown = 50
-const fullHistoryObservers = 60
 
-var log = logger.GetOrCreate("p2p/libp2p/networksharding")
+const loggerName = "p2p/libp2p/networksharding"
+
+var log = logger.GetOrCreate(loggerName)
 
 var leadingZerosCount = []int{
 	8, 7, 6, 6, 5, 5, 5, 5,
@@ -79,7 +80,6 @@ type ArgListsSharder struct {
 	SelfPeerId           peer.ID
 	P2pConfig            config.P2PConfig
 	PreferredPeersHolder p2p.PreferredPeersHolderHandler
-	NodeOperationMode    p2p.NodeOperation
 }
 
 // listsSharder is the struct able to compute an eviction list of connected peers id according to the
@@ -96,7 +96,6 @@ type listsSharder struct {
 	maxIntraShardObservers  int
 	maxCrossShardObservers  int
 	maxSeeders              int
-	maxFullHistoryObservers int
 	maxUnknown              int
 	mutSeeders              sync.RWMutex
 	seeders                 []string
@@ -111,7 +110,6 @@ type peersConnections struct {
 	intraShardObservers  int
 	crossShardObservers  int
 	seeders              int
-	fullHistoryObservers int
 	unknown              int
 }
 
@@ -153,7 +151,6 @@ func NewListsSharder(arg ArgListsSharder) (*listsSharder, error) {
 		maxIntraShardObservers:  peersConn.intraShardObservers,
 		maxCrossShardObservers:  peersConn.crossShardObservers,
 		maxSeeders:              peersConn.seeders,
-		maxFullHistoryObservers: peersConn.fullHistoryObservers,
 		maxUnknown:              peersConn.unknown,
 		preferredPeersHolder:    arg.PreferredPeersHolder,
 	}
@@ -169,22 +166,18 @@ func processNumConnections(arg ArgListsSharder) (peersConnections, error) {
 		intraShardObservers:  int(arg.P2pConfig.Sharding.MaxIntraShardObservers),
 		crossShardObservers:  int(arg.P2pConfig.Sharding.MaxCrossShardObservers),
 		seeders:              int(arg.P2pConfig.Sharding.MaxSeeders),
-		fullHistoryObservers: 0,
-	}
-	if arg.NodeOperationMode == p2p.FullArchiveMode {
-		peersConn.fullHistoryObservers = int(arg.P2pConfig.Sharding.AdditionalConnections.MaxFullHistoryObservers)
-		peersConn.maxPeerCount += peersConn.fullHistoryObservers
 	}
 
-	if peersConn.crossShardObservers+peersConn.intraShardObservers+peersConn.fullHistoryObservers == 0 {
+	log = logger.GetOrCreate(arg.P2pConfig.Logger.Prefix + loggerName)
+	if peersConn.crossShardObservers+peersConn.intraShardObservers == 0 {
 		log.Warn("No connections to observers are possible. This is NOT a recommended setting!")
 	}
 
 	providedPeers := peersConn.intraShardValidators + peersConn.crossShardValidators +
 		peersConn.intraShardObservers + peersConn.crossShardObservers +
-		peersConn.seeders + peersConn.fullHistoryObservers
+		peersConn.seeders
 	if providedPeers+minUnknownPeers > peersConn.maxPeerCount {
-		return peersConnections{}, fmt.Errorf("%w, maxValidators + maxObservers + seeders + full archive nodes should be less than %d", p2p.ErrInvalidValue, peersConn.maxPeerCount)
+		return peersConnections{}, fmt.Errorf("%w, maxValidators + maxObservers + seeders should be less than %d", p2p.ErrInvalidValue, peersConn.maxPeerCount)
 	}
 
 	peersConn.unknown = peersConn.maxPeerCount - providedPeers
@@ -201,12 +194,10 @@ func (ls *listsSharder) ComputeEvictionList(pidList []peer.ID) []peer.ID {
 	existingNumCrossShardValidators := len(peerDistances[crossShardValidators])
 	existingNumCrossShardObservers := len(peerDistances[crossShardObservers])
 	existingNumSeeders := len(peerDistances[seeders])
-	existingNumFullHistoryObservers := len(peerDistances[fullHistoryObservers])
 	existingNumUnknown := len(peerDistances[unknown])
 
 	var numIntraShardValidators, numCrossShardValidators int
 	var numIntraShardObservers, numCrossShardObservers int
-	var numFullHistoryObservers int
 	var numSeeders, numUnknown, remaining int
 
 	numIntraShardValidators, remaining = computeUsedAndSpare(existingNumIntraShardValidators, ls.maxIntraShardValidators)
@@ -214,7 +205,6 @@ func (ls *listsSharder) ComputeEvictionList(pidList []peer.ID) []peer.ID {
 	numIntraShardObservers, remaining = computeUsedAndSpare(existingNumIntraShardObservers, ls.maxIntraShardObservers+remaining)
 	numCrossShardObservers, remaining = computeUsedAndSpare(existingNumCrossShardObservers, ls.maxCrossShardObservers+remaining)
 	numSeeders, _ = computeUsedAndSpare(existingNumSeeders, ls.maxSeeders) // we are not mixing remaining value. We are strict with the number of seeders
-	numFullHistoryObservers, _ = computeUsedAndSpare(existingNumFullHistoryObservers, ls.maxFullHistoryObservers)
 	numUnknown, _ = computeUsedAndSpare(existingNumUnknown, ls.maxUnknown+remaining)
 
 	evictionProposed := evict(peerDistances[intraShardValidators], numIntraShardValidators)
@@ -225,8 +215,6 @@ func (ls *listsSharder) ComputeEvictionList(pidList []peer.ID) []peer.ID {
 	e = evict(peerDistances[crossShardObservers], numCrossShardObservers)
 	evictionProposed = append(evictionProposed, e...)
 	e = evict(peerDistances[seeders], numSeeders)
-	evictionProposed = append(evictionProposed, e...)
-	e = evict(peerDistances[fullHistoryObservers], numFullHistoryObservers)
 	evictionProposed = append(evictionProposed, e...)
 	e = evict(peerDistances[unknown], numUnknown)
 	evictionProposed = append(evictionProposed, e...)
@@ -265,7 +253,6 @@ func (ls *listsSharder) splitPeerIds(peers []peer.ID) map[int]sorting.PeerDistan
 		intraShardObservers:  {},
 		crossShardValidators: {},
 		crossShardObservers:  {},
-		fullHistoryObservers: {},
 		seeders:              {},
 		unknown:              {},
 	}
@@ -315,12 +302,7 @@ func (ls *listsSharder) splitPeerIds(peers []peer.ID) map[int]sorting.PeerDistan
 		case core.ValidatorPeer:
 			peerDistances[intraShardValidators] = append(peerDistances[intraShardValidators], pd)
 		case core.ObserverPeer:
-			shouldAppendToFullHistory := peerInfo.PeerSubType == core.FullHistoryObserver && ls.maxFullHistoryObservers > 0
-			if shouldAppendToFullHistory {
-				peerDistances[fullHistoryObservers] = append(peerDistances[fullHistoryObservers], pd)
-			} else {
-				peerDistances[intraShardObservers] = append(peerDistances[intraShardObservers], pd)
-			}
+			peerDistances[intraShardObservers] = append(peerDistances[intraShardObservers], pd)
 		}
 	}
 

--- a/p2p/libp2p/networksharding/listsSharder_test.go
+++ b/p2p/libp2p/networksharding/listsSharder_test.go
@@ -185,7 +185,6 @@ func TestNewListsSharder_NormalShouldWork(t *testing.T) {
 	arg.P2pConfig.Sharding.MaxIntraShardObservers = 4
 	arg.P2pConfig.Sharding.MaxCrossShardObservers = 3
 	arg.P2pConfig.Sharding.MaxSeeders = 2
-	arg.P2pConfig.Sharding.AdditionalConnections.MaxFullHistoryObservers = 1
 	ls, err := networksharding.NewListsSharder(arg)
 
 	assert.False(t, check.IfNil(ls))
@@ -196,33 +195,6 @@ func TestNewListsSharder_NormalShouldWork(t *testing.T) {
 	assert.Equal(t, 4, ls.GetMaxIntraShardObservers())
 	assert.Equal(t, 3, ls.GetMaxCrossShardObservers())
 	assert.Equal(t, 2, ls.GetMaxSeeders())
-	assert.Equal(t, 0, ls.GetMaxFullHistoryObservers())
-	assert.Equal(t, 5, ls.GetMaxUnknown())
-}
-
-func TestNewListsSharder_FullArchiveShouldWork(t *testing.T) {
-	t.Parallel()
-
-	arg := createMockListSharderArguments()
-	arg.NodeOperationMode = p2p.FullArchiveMode
-	arg.P2pConfig.Sharding.TargetPeerCount = 25
-	arg.P2pConfig.Sharding.MaxIntraShardValidators = 6
-	arg.P2pConfig.Sharding.MaxCrossShardValidators = 5
-	arg.P2pConfig.Sharding.MaxIntraShardObservers = 4
-	arg.P2pConfig.Sharding.MaxCrossShardObservers = 3
-	arg.P2pConfig.Sharding.MaxSeeders = 2
-	arg.P2pConfig.Sharding.AdditionalConnections.MaxFullHistoryObservers = 1
-	ls, err := networksharding.NewListsSharder(arg)
-
-	assert.False(t, check.IfNil(ls))
-	assert.Nil(t, err)
-	assert.Equal(t, 26, ls.GetMaxPeerCount())
-	assert.Equal(t, 6, ls.GetMaxIntraShardValidators())
-	assert.Equal(t, 5, ls.GetMaxCrossShardValidators())
-	assert.Equal(t, 4, ls.GetMaxIntraShardObservers())
-	assert.Equal(t, 3, ls.GetMaxCrossShardObservers())
-	assert.Equal(t, 2, ls.GetMaxSeeders())
-	assert.Equal(t, 1, ls.GetMaxFullHistoryObservers())
 	assert.Equal(t, 5, ls.GetMaxUnknown())
 }
 

--- a/p2p/messageCheck/messageVerifier.go
+++ b/p2p/messageCheck/messageVerifier.go
@@ -11,7 +11,9 @@ import (
 	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
-var log = logger.GetOrCreate("p2p/messagecheck")
+const loggerName = "p2p/messagecheck"
+
+var log = logger.GetOrCreate(loggerName)
 
 type messageVerifier struct {
 	marshaller marshal.Marshalizer
@@ -20,8 +22,9 @@ type messageVerifier struct {
 
 // ArgsMessageVerifier defines the arguments needed to create a messageVerifier
 type ArgsMessageVerifier struct {
-	Marshaller marshal.Marshalizer
-	P2PSigner  p2pSigner
+	Marshaller   marshal.Marshalizer
+	P2PSigner    p2pSigner
+	LoggerPrefix string
 }
 
 // NewMessageVerifier will create a new instance of messageVerifier
@@ -29,6 +32,10 @@ func NewMessageVerifier(args ArgsMessageVerifier) (*messageVerifier, error) {
 	err := checkArgs(args)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(args.LoggerPrefix) > 0 {
+		log = logger.GetOrCreate(args.LoggerPrefix + loggerName)
 	}
 
 	return &messageVerifier{

--- a/p2p/rating/peersRatingHandler.go
+++ b/p2p/rating/peersRatingHandler.go
@@ -21,14 +21,16 @@ const (
 	decreaseFactor = -1
 	minNumOfPeers  = 1
 	int32Size      = 4
+	loggerName     = "p2p/peersRating"
 )
 
-var log = logger.GetOrCreate("p2p/peersRating")
+var log = logger.GetOrCreate(loggerName)
 
 // ArgPeersRatingHandler is the DTO used to create a new peers rating handler
 type ArgPeersRatingHandler struct {
 	TopRatedCache types.Cacher
 	BadRatedCache types.Cacher
+	LoggerPrefix  string
 }
 
 type peersRatingHandler struct {
@@ -42,6 +44,10 @@ func NewPeersRatingHandler(args ArgPeersRatingHandler) (*peersRatingHandler, err
 	err := checkHandlerArgs(args)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(args.LoggerPrefix) > 0 {
+		log = logger.GetOrCreate(args.LoggerPrefix + loggerName)
 	}
 
 	return &peersRatingHandler{


### PR DESCRIPTION
- removed NodeOperation as param on net messenger
- added logger prefix on all components to differentiate the regular messenger among the others