### PR TITLE
`feat/ack timeout and refactoring`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/libp2p/go-libp2p-kbucket v0.4.7
 	github.com/libp2p/go-libp2p-pubsub v0.8.1
 	github.com/multiformats/go-multiaddr v0.6.0
-	github.com/multiversx/mx-chain-core-go v1.2.1-0.20230510143029-ab37792342df
+	github.com/multiversx/mx-chain-core-go v1.2.5
 	github.com/multiversx/mx-chain-crypto-go v1.2.6
 	github.com/multiversx/mx-chain-logger-go v1.0.11
 	github.com/multiversx/mx-chain-storage-go v1.0.8

--- a/go.sum
+++ b/go.sum
@@ -467,8 +467,8 @@ github.com/multiformats/go-varint v0.0.2/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXS
 github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/multiformats/go-varint v0.0.6 h1:gk85QWKxh3TazbLxED/NlDVv8+q+ReFJk7Y2W/KhfNY=
 github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
-github.com/multiversx/mx-chain-core-go v1.2.1-0.20230510143029-ab37792342df h1:ADV4QOB2Tg42SYyVmYNq4FBXCc4bzD5EA66IFhF+fb0=
-github.com/multiversx/mx-chain-core-go v1.2.1-0.20230510143029-ab37792342df/go.mod h1:jzYFSiYBuO0dGpGFXnZWSwcwcKP7Flyn/X41y4zIQrQ=
+github.com/multiversx/mx-chain-core-go v1.2.5 h1:uIZSqRygJAxv+pGuZnoSMwS4t10C/paasuwps5nxrIQ=
+github.com/multiversx/mx-chain-core-go v1.2.5/go.mod h1:jzYFSiYBuO0dGpGFXnZWSwcwcKP7Flyn/X41y4zIQrQ=
 github.com/multiversx/mx-chain-crypto-go v1.2.6 h1:yxsjAQGh62los+iYmORMfh3w9qen0xbYlmwU0juNSeg=
 github.com/multiversx/mx-chain-crypto-go v1.2.6/go.mod h1:rOj0Rr19HTOYt9YTeym7RKxlHt91NXln3LVKjHKVmA0=
 github.com/multiversx/mx-chain-logger-go v1.0.11 h1:DFsHa+sc5fKwhDR50I8uBM99RTDTEW68ESyr5ALRDwE=

--- a/websocket/client/client.go
+++ b/websocket/client/client.go
@@ -18,6 +18,7 @@ import (
 // ArgsWebSocketClient holds the arguments needed for creating a client
 type ArgsWebSocketClient struct {
 	RetryDurationInSeconds     int
+	AckTimeoutInSeconds        int
 	WithAcknowledge            bool
 	BlockingAckOnError         bool
 	DropMessagesIfNoConnection bool
@@ -47,6 +48,7 @@ func NewWebSocketClient(args ArgsWebSocketClient) (*client, error) {
 		PayloadConverter:   args.PayloadConverter,
 		Log:                args.Log,
 		RetryDurationInSec: args.RetryDurationInSeconds,
+		AckTimeoutInSec:    args.AckTimeoutInSeconds,
 		BlockingAckOnError: args.BlockingAckOnError,
 		WithAcknowledge:    args.WithAcknowledge,
 	}

--- a/websocket/data/errors.go
+++ b/websocket/data/errors.go
@@ -20,6 +20,9 @@ var ErrEmptyUrl = errors.New("empty websocket url provided")
 // ErrZeroValueRetryDuration signals that a zero value for retry duration has been provided
 var ErrZeroValueRetryDuration = errors.New("zero value provided for retry duration")
 
+// ErrZeroValueAckTimeout signals that a zero value for acknowledge timeout has been provided
+var ErrZeroValueAckTimeout = errors.New("zero value provided for acknowledge timeout")
+
 // ErrConnectionAlreadyOpen signal that the WebSocket connection was already open
 var ErrConnectionAlreadyOpen = errors.New("connection already open")
 
@@ -34,3 +37,6 @@ var ErrInvalidWebSocketHostMode = errors.New("invalid web socket host mode")
 
 // ErrNoClientsConnected is an error signal indicating the absence of any connected clients
 var ErrNoClientsConnected = errors.New("no client connected")
+
+// ErrAckTimeout signals that an acknowledgment timeout has been reached
+var ErrAckTimeout = errors.New("acknowledge waiting timeout occurred")

--- a/websocket/data/operations.go
+++ b/websocket/data/operations.go
@@ -15,6 +15,7 @@ type WebSocketConfig struct {
 	Mode                       string // The host operation mode: 'client' or 'server'.
 	RetryDurationInSec         int    // The duration in seconds to wait before retrying the connection in case of failure.
 	WithAcknowledge            bool   // Set to `true` to enable message acknowledgment mechanism.
+	AcknowledgeTimeoutInSec    int    // The duration in seconds to wait for an acknowledgement message
 	BlockingAckOnError         bool   // Set to `true` to send the acknowledgment message only if the processing part of a message succeeds. If an error occurs during processing, the acknowledgment will not be sent.
 	DropMessagesIfNoConnection bool   // Set to `true` to drop messages if there is no active WebSocket connection to send to.
 }

--- a/websocket/examples/sendreceive/README.md
+++ b/websocket/examples/sendreceive/README.md
@@ -13,11 +13,16 @@ starts a WebSocket client and waits to receive a message.
 ``` bash
     go build && ./client
 ```
+
+> One can run multiple instances of the `client` binary.
+
+
+
 4. Open another terminal or command prompt.
 5. Navigate to the server folder.
 6. Build and run the server
 ``` bash
     go build && ./server
 ```
-7. Wait for the server to successfully send the message and the client to receive it.
-8. Once the message has been sent and received successfully, the processes will end.
+7. Wait for the server to successfully send the messages and the clients to receive them.
+8. Close the clients and the server.

--- a/websocket/examples/sendreceive/server/main.go
+++ b/websocket/examples/sendreceive/server/main.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/multiversx/mx-chain-communication-go/websocket/data"
@@ -24,6 +28,7 @@ func main() {
 			WithAcknowledge:            true,
 			BlockingAckOnError:         false,
 			DropMessagesIfNoConnection: false,
+			AcknowledgeTimeoutInSec:    10,
 		},
 		Marshaller: marshaller,
 		Log:        log,
@@ -35,11 +40,31 @@ func main() {
 		return
 	}
 
-	for {
-		err = wsServer.Send([]byte("message"), "test")
-		if err == nil {
-			break
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	defer timer.Stop()
+	count := 0
+
+	func() {
+		for {
+			message := fmt.Sprintf("message #%d", count)
+			err = wsServer.Send([]byte(message), "test")
+			if err == nil {
+				count++
+				log.Info("message sent to clients", "count", count)
+			}
+			timer.Reset(100 * time.Millisecond)
+
+			select {
+			case <-timer.C:
+			case <-interrupt:
+				return
+			}
 		}
-		time.Sleep(100 * time.Millisecond)
-	}
+	}()
+
+	err = wsServer.Close()
+	log.LogIfError(err)
 }

--- a/websocket/factory/factoryHost.go
+++ b/websocket/factory/factoryHost.go
@@ -42,6 +42,7 @@ func createWebSocketClient(args ArgsWebSocketHost) (FullDuplexHost, error) {
 		Log:                        args.Log,
 		BlockingAckOnError:         args.WebSocketConfig.BlockingAckOnError,
 		DropMessagesIfNoConnection: args.WebSocketConfig.DropMessagesIfNoConnection,
+		AckTimeoutInSeconds:        args.WebSocketConfig.AcknowledgeTimeoutInSec,
 	})
 }
 
@@ -59,6 +60,7 @@ func createWebSocketServer(args ArgsWebSocketHost) (FullDuplexHost, error) {
 		Log:                        args.Log,
 		BlockingAckOnError:         args.WebSocketConfig.BlockingAckOnError,
 		DropMessagesIfNoConnection: args.WebSocketConfig.DropMessagesIfNoConnection,
+		AckTimeoutInSeconds:        args.WebSocketConfig.AcknowledgeTimeoutInSec,
 	})
 	if err != nil {
 		return nil, err

--- a/websocket/integrationTests/testInitializer.go
+++ b/websocket/integrationTests/testInitializer.go
@@ -27,6 +27,7 @@ func createClient(url string, log core.Logger) (hostFactory.FullDuplexHost, erro
 		PayloadConverter:           payloadConverter,
 		Log:                        log,
 		DropMessagesIfNoConnection: false,
+		AckTimeoutInSeconds:        retryDurationInSeconds,
 	})
 }
 
@@ -38,6 +39,7 @@ func createServer(url string, log core.Logger) (hostFactory.FullDuplexHost, erro
 		PayloadConverter:           payloadConverter,
 		Log:                        log,
 		DropMessagesIfNoConnection: false,
+		AckTimeoutInSeconds:        retryDurationInSeconds,
 	})
 }
 

--- a/websocket/server/server.go
+++ b/websocket/server/server.go
@@ -19,6 +19,7 @@ import (
 // ArgsWebSocketServer holds all the components needed to create a server
 type ArgsWebSocketServer struct {
 	RetryDurationInSeconds     int
+	AckTimeoutInSeconds        int
 	BlockingAckOnError         bool
 	WithAcknowledge            bool
 	DropMessagesIfNoConnection bool
@@ -31,6 +32,7 @@ type server struct {
 	blockingAckOnError         bool
 	withAcknowledge            bool
 	dropMessagesIfNoConnection bool
+	ackTimeoutInSec            int
 	payloadConverter           webSocket.PayloadConverter
 	retryDuration              time.Duration
 	log                        core.Logger
@@ -54,6 +56,7 @@ func NewWebSocketServer(args ArgsWebSocketServer) (*server, error) {
 		payloadHandler:             webSocket.NewNilPayloadHandler(),
 		withAcknowledge:            args.WithAcknowledge,
 		dropMessagesIfNoConnection: args.DropMessagesIfNoConnection,
+		ackTimeoutInSec:            args.AckTimeoutInSeconds,
 	}
 
 	wsServer.initializeServer(args.URL, data.WSRoute)
@@ -82,6 +85,7 @@ func (s *server) connectionHandler(connection webSocket.WSConClient) {
 		PayloadConverter:   s.payloadConverter,
 		Log:                s.log,
 		RetryDurationInSec: int(s.retryDuration.Seconds()),
+		AckTimeoutInSec:    s.ackTimeoutInSec,
 		BlockingAckOnError: s.blockingAckOnError,
 		WithAcknowledge:    s.withAcknowledge,
 	})


### PR DESCRIPTION
- Extended the `transceiver` component to return an error in case of an acknowledge timeout. #22, #26 
- Updated the `mx-chain-core-go` module with a proper release tag. #17 
- Extended the `examples` for the `WebSocket` host. #28 