### PR TITLE
Fix WebSocket connection problem

### DIFF
--- a/websocket/client/client.go
+++ b/websocket/client/client.go
@@ -119,7 +119,7 @@ func (c *client) start() {
 			closed := c.transceiver.Listen(c.wsConn)
 			if closed {
 				err := c.wsConn.Close()
-				c.log.LogIfError(err, "received close from server: initialized close()", "close error", err)
+				c.log.Debug("try to close the connection", "close error", err)
 			}
 
 			timer.Reset(c.retryDuration)

--- a/websocket/data/consts.go
+++ b/websocket/data/consts.go
@@ -1,4 +1,10 @@
 package data
 
-// ClosedConnectionMessage is the message that is received when try to send a message over a closed WebSocket connection
-const ClosedConnectionMessage = "use of closed network connection"
+const (
+	// ClosedConnectionMessage is the message that is received when try to send a message over a closed WebSocket connection
+	ClosedConnectionMessage = "use of closed network connection"
+	// ResetByPeerConnectionMessage is the message that is received from server is case of a connection with problems
+	ResetByPeerConnectionMessage = "connection reset by peer"
+	// BrokenPipeMessage is the error message that is received in case of connection with problems
+	BrokenPipeMessage = "broken pipe"
+)

--- a/websocket/data/consts.go
+++ b/websocket/data/consts.go
@@ -3,8 +3,4 @@ package data
 const (
 	// ClosedConnectionMessage is the message that is received when try to send a message over a closed WebSocket connection
 	ClosedConnectionMessage = "use of closed network connection"
-	// ResetByPeerConnectionMessage is the message that is received from server is case of a connection with problems
-	ResetByPeerConnectionMessage = "connection reset by peer"
-	// BrokenPipeMessage is the error message that is received in case of connection with problems
-	BrokenPipeMessage = "broken pipe"
 )

--- a/websocket/examples/sendreceive/client/main.go
+++ b/websocket/examples/sendreceive/client/main.go
@@ -16,7 +16,7 @@ import (
 var (
 	marshaller, _ = factory.NewMarshalizer("json")
 	log           = logger.GetOrCreate("client")
-	url           = "localhost:12345"
+	url           = ":12345"
 )
 
 func main() {

--- a/websocket/examples/sendreceive/client/main.go
+++ b/websocket/examples/sendreceive/client/main.go
@@ -20,6 +20,7 @@ var (
 )
 
 func main() {
+	_ = logger.SetLogLevel("*:DEBUG")
 	args := factoryHost.ArgsWebSocketHost{
 		WebSocketConfig: data.WebSocketConfig{
 			URL:                        url,

--- a/websocket/integrationTests/clientAndServer_test.go
+++ b/websocket/integrationTests/clientAndServer_test.go
@@ -53,10 +53,11 @@ func TestStartServerAddClientAndCloseClientAndServerShouldReceiveClose(t *testin
 	url := "localhost:" + getFreePort()
 
 	receivedClose := make(chan struct{})
+	payloadWasProcessed := false
 	serverReceivedCloseMessage := false
 	log := &testscommon.LoggerStub{
 		InfoCalled: func(message string, args ...interface{}) {
-			if strings.Contains(message, "connection closed") {
+			if strings.Contains(message, "connection closed") && payloadWasProcessed {
 				serverReceivedCloseMessage = true
 				receivedClose <- struct{}{}
 			}
@@ -69,6 +70,7 @@ func TestStartServerAddClientAndCloseClientAndServerShouldReceiveClose(t *testin
 	_ = wsServer.SetPayloadHandler(&testscommon.PayloadHandlerStub{
 		ProcessPayloadCalled: func(payload []byte, topic string, version uint32) error {
 			require.Equal(t, []byte("test"), payload)
+			payloadWasProcessed = true
 			return nil
 		},
 	})

--- a/websocket/transceiver/transceiver_test.go
+++ b/websocket/transceiver/transceiver_test.go
@@ -151,7 +151,10 @@ func TestReceiver_ListenAndSendAck(t *testing.T) {
 	}
 
 	go func() {
-		webSocketsReceiver.Listen(conn)
+		closed := true
+		for closed {
+			closed = webSocketsReceiver.Listen(conn)
+		}
 	}()
 
 	wg.Wait()

--- a/websocket/transceiver/transceiver_test.go
+++ b/websocket/transceiver/transceiver_test.go
@@ -118,11 +118,11 @@ func TestReceiver_ListenAndSendAck(t *testing.T) {
 	})
 
 	wg := &sync.WaitGroup{}
-	wg.Add(2)
+	wg.Add(1)
 
 	count := 0
 	conn := &testscommon.WebsocketConnectionStub{
-		ReadMessageCalled: func() (messageType int, payload []byte, err error) {
+		ReadMessageCalled: func() (int, []byte, error) {
 			time.Sleep(500 * time.Millisecond)
 			if count >= 1 {
 				wg.Done()
@@ -141,8 +141,8 @@ func TestReceiver_ListenAndSendAck(t *testing.T) {
 		CloseCalled: func() error {
 			return nil
 		},
-		WriteMessageCalled: func(messageType int, data []byte) error {
-			if count == 1 {
+		WriteMessageCalled: func(messageType int, d []byte) error {
+			if count == 1 && messageType == data.PayloadMessage {
 				count++
 				return errors.New("local error")
 			}
@@ -151,8 +151,8 @@ func TestReceiver_ListenAndSendAck(t *testing.T) {
 	}
 
 	go func() {
-		closed := true
-		for closed {
+		closed := false
+		for !closed {
 			closed = webSocketsReceiver.Listen(conn)
 		}
 	}()

--- a/websocket/transceiver/transceiver_test.go
+++ b/websocket/transceiver/transceiver_test.go
@@ -124,7 +124,6 @@ func TestReceiver_ListenAndSendAck(t *testing.T) {
 			mutex.Lock()
 			time.Sleep(500 * time.Millisecond)
 			if count == 2 {
-				count++
 				mutex.Unlock()
 				return 0, nil, errors.New("closed")
 			}

--- a/websocket/transceiver/transceiver_test.go
+++ b/websocket/transceiver/transceiver_test.go
@@ -124,7 +124,7 @@ func TestReceiver_ListenAndSendAck(t *testing.T) {
 	conn := &testscommon.WebsocketConnectionStub{
 		ReadMessageCalled: func() (int, []byte, error) {
 			time.Sleep(500 * time.Millisecond)
-			if count >= 1 {
+			if count == 2 {
 				wg.Done()
 				return 0, nil, errors.New("closed")
 			}

--- a/websocket/transceiver/transceiver_test.go
+++ b/websocket/transceiver/transceiver_test.go
@@ -151,7 +151,10 @@ func TestReceiver_ListenAndSendAck(t *testing.T) {
 		},
 	}
 
+	secondWg := sync.WaitGroup{}
+	secondWg.Add(1)
 	go func() {
+		defer secondWg.Done()
 		closed := false
 		for !closed {
 			closed = webSocketsReceiver.Listen(conn)
@@ -161,6 +164,7 @@ func TestReceiver_ListenAndSendAck(t *testing.T) {
 	wg.Wait()
 	_ = webSocketsReceiver.Close()
 	_ = conn.Close()
+	secondWg.Wait()
 
 	require.GreaterOrEqual(t, count, 2)
 }

--- a/websocket/transceiver/transceiver_test.go
+++ b/websocket/transceiver/transceiver_test.go
@@ -117,7 +117,7 @@ func TestReceiver_ListenAndSendAck(t *testing.T) {
 		},
 	})
 
-	mutex := sync.Mutex{}
+	mutex := sync.RWMutex{}
 	count := uint64(0)
 	conn := &testscommon.WebsocketConnectionStub{
 		ReadMessageCalled: func() (int, []byte, error) {
@@ -152,7 +152,9 @@ func TestReceiver_ListenAndSendAck(t *testing.T) {
 	_ = webSocketsReceiver.Close()
 	_ = conn.Close()
 
+	mutex.RLock()
 	require.GreaterOrEqual(t, count, uint64(2))
+	mutex.RUnlock()
 }
 
 func TestSender_AddConnectionSendAndClose(t *testing.T) {

--- a/websocket/transceiver/transceiver_test.go
+++ b/websocket/transceiver/transceiver_test.go
@@ -162,7 +162,7 @@ func TestReceiver_ListenAndSendAck(t *testing.T) {
 	_ = webSocketsReceiver.Close()
 	_ = conn.Close()
 
-	require.Equal(t, 2, count)
+	require.GreaterOrEqual(t, count, 2)
 }
 
 func TestSender_AddConnectionSendAndClose(t *testing.T) {

--- a/websocket/transceiver/transceiver_test.go
+++ b/websocket/transceiver/transceiver_test.go
@@ -126,6 +126,7 @@ func TestReceiver_ListenAndSendAck(t *testing.T) {
 			time.Sleep(500 * time.Millisecond)
 			if count == 2 {
 				wg.Done()
+				count++
 				return 0, nil, errors.New("closed")
 			}
 			count++

--- a/websocket/transceiver/transceiver_test.go
+++ b/websocket/transceiver/transceiver_test.go
@@ -295,7 +295,7 @@ func TestWsTransceiver_ListenReturnsTrue(t *testing.T) {
 	conn := &testscommon.WebsocketConnectionStub{
 		ReadMessageCalled: func() (messageType int, payload []byte, err error) {
 			if count == 2 {
-				return 0, nil, errors.New(data.BrokenPipeMessage)
+				return 0, nil, errors.New("test error")
 			}
 			count++
 


### PR DESCRIPTION
- Reopen connection in case of an error with a `broken pipe` message or `connection reset by peer` message