### PR TITLE
Added protocol ID provider checker

### DIFF
--- a/p2p/interface.go
+++ b/p2p/interface.go
@@ -72,7 +72,7 @@ type ConnectionsHandler interface {
 	ThresholdMinConnectedPeers() int
 	SetThresholdMinConnectedPeers(minConnectedPeers int) error
 	SetPeerDenialEvaluator(handler PeerDenialEvaluator) error
-	HasCompatibleProtocolID(pid core.PeerID) bool
+	HasCompatibleProtocolID(address string) bool
 	IsInterfaceNil() bool
 }
 

--- a/p2p/interface.go
+++ b/p2p/interface.go
@@ -72,6 +72,7 @@ type ConnectionsHandler interface {
 	ThresholdMinConnectedPeers() int
 	SetThresholdMinConnectedPeers(minConnectedPeers int) error
 	SetPeerDenialEvaluator(handler PeerDenialEvaluator) error
+	HasCompatibleProtocolID(pid core.PeerID) bool
 	IsInterfaceNil() bool
 }
 

--- a/p2p/libp2p/connectionsHandler.go
+++ b/p2p/libp2p/connectionsHandler.go
@@ -133,12 +133,19 @@ func (handler *connectionsHandler) Peers() []core.PeerID {
 	return peers
 }
 
-// HasCompatibleProtocolID returns true if the provided peer ID has at least one protocol in common with the current node
-func (handler *connectionsHandler) HasCompatibleProtocolID(pid core.PeerID) bool {
-	protocols, err := handler.p2pHost.Peerstore().GetProtocols(peer.ID(pid))
+// HasCompatibleProtocolID returns true if the provided address has at least one protocol in common with the current node
+func (handler *connectionsHandler) HasCompatibleProtocolID(address string) bool {
+	addrInfo, err := handler.p2pHost.AddressToPeerInfo(address)
+	if err != nil {
+		handler.log.Trace("connectionsHandler.AddressToPeerInfo error getting address info",
+			"address", address, "error", err.Error())
+		return false
+	}
+
+	protocols, err := handler.p2pHost.Peerstore().GetProtocols(addrInfo.ID)
 	if err != nil {
 		handler.log.Trace("connectionsHandler.HasCompatibleProtocolID error getting protocols",
-			"pid", pid.Pretty(), "error", err.Error())
+			"pid", addrInfo.ID.String(), "error", err.Error())
 		return false
 	}
 

--- a/p2p/libp2p/connectionsHandler.go
+++ b/p2p/libp2p/connectionsHandler.go
@@ -16,6 +16,7 @@ import (
 )
 
 const timeBetweenPeerPrints = time.Second * 20
+const kadProtocol = "/kad/1.0.0"
 
 // ArgConnectionsHandler is the DTO struct used to create a new instance of connections handler
 type ArgConnectionsHandler struct {
@@ -30,6 +31,7 @@ type ArgConnectionsHandler struct {
 	ConnectionsMetric    ConnectionsMetric
 	NetworkType          p2p.NetworkType
 	Logger               p2p.Logger
+	ProtocolID           string
 }
 
 type connectionsHandler struct {
@@ -47,6 +49,7 @@ type connectionsHandler struct {
 	connectionsMetric    ConnectionsMetric
 	networkType          p2p.NetworkType
 	log                  p2p.Logger
+	protocolID           string
 }
 
 // NewConnectionsHandler creates a new connections manager
@@ -71,6 +74,7 @@ func NewConnectionsHandler(args ArgConnectionsHandler) (*connectionsHandler, err
 		connectionsMetric:    args.ConnectionsMetric,
 		log:                  args.Logger,
 		networkType:          args.NetworkType,
+		protocolID:           args.ProtocolID,
 	}
 
 	go handler.printLogs()
@@ -127,6 +131,25 @@ func (handler *connectionsHandler) Peers() []core.PeerID {
 		peers = append(peers, core.PeerID(p))
 	}
 	return peers
+}
+
+// HasCompatibleProtocolID returns true if the provided peer ID has at least one protocol in common with the current node
+func (handler *connectionsHandler) HasCompatibleProtocolID(pid core.PeerID) bool {
+	protocols, err := handler.p2pHost.Peerstore().GetProtocols(peer.ID(pid))
+	if err != nil {
+		handler.log.Trace("connectionsHandler.HasCompatibleProtocolID error getting protocols",
+			"pid", pid.Pretty(), "error", err.Error())
+		return false
+	}
+
+	for i := 0; i < len(protocols); i++ {
+		// this suffix is done automatically in dht.go L280 (v1proto := cfg.ProtocolPrefix + kad1)
+		if handler.protocolID+kadProtocol == string(protocols[i]) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Addresses returns all addresses found in peerstore

--- a/p2p/libp2p/export_test.go
+++ b/p2p/libp2p/export_test.go
@@ -24,6 +24,7 @@ var SequenceNumberSize = sequenceNumberSize
 
 const CurrentTopicMessageVersion = currentTopicMessageVersion
 const PollWaitForConnectionsInterval = pollWaitForConnectionsInterval
+const KadProtocol = kadProtocol
 
 // SetHost -
 func (handler *connectionsHandler) SetHost(newHost ConnectableHost) {
@@ -314,6 +315,7 @@ func NewConnectionsHandlerWithNoRoutine(args ArgConnectionsHandler) *connections
 		peerID:               args.PeerID,
 		connectionsMetric:    args.ConnectionsMetric,
 		log:                  args.Logger,
+		protocolID:           args.ProtocolID,
 	}
 }
 

--- a/p2p/libp2p/netMessenger.go
+++ b/p2p/libp2p/netMessenger.go
@@ -413,6 +413,7 @@ func addComponentsToNode(
 		ConnectionsMetric:    connectionsMetric,
 		NetworkType:          p2pNode.networkType,
 		Logger:               p2pNode.log,
+		ProtocolID:           args.P2pConfig.KadDhtPeerDiscovery.ProtocolID,
 	}
 	p2pNode.ConnectionsHandler, err = NewConnectionsHandler(argsConnectionsHandler)
 	if err != nil {

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -2323,3 +2323,58 @@ func TestParseTransportOptions(t *testing.T) {
 		})
 	})
 }
+
+func TestNetworkMessenger_HasCompatibleProtocolID(t *testing.T) {
+	arg1 := createMockNetworkArgs()
+	arg1.P2pConfig.KadDhtPeerDiscovery = config.KadDhtPeerDiscoveryConfig{
+		Enabled:                          true,
+		Type:                             "optimized",
+		RefreshIntervalInSec:             1,
+		RoutingTableRefreshIntervalInSec: 1,
+		ProtocolID:                       "/erd/kad/1.1.0",
+		InitialPeerList:                  nil,
+		BucketSize:                       100,
+	}
+	messenger1, _ := libp2p.NewNetworkMessenger(arg1)
+
+	arg2 := createMockNetworkArgs()
+	arg2.P2pConfig.KadDhtPeerDiscovery = arg1.P2pConfig.KadDhtPeerDiscovery // copy by value
+	messenger2, _ := libp2p.NewNetworkMessenger(arg2)
+
+	arg3 := createMockNetworkArgs()
+	arg3.P2pConfig.KadDhtPeerDiscovery = arg1.P2pConfig.KadDhtPeerDiscovery // copy by value
+	arg3.P2pConfig.KadDhtPeerDiscovery.ProtocolID = "/erd/kad/1.2.0"        // another protocol ID
+	messenger3, _ := libp2p.NewNetworkMessenger(arg3)
+
+	_ = messenger2.CreateTopic("test", true)
+	_ = messenger3.CreateTopic("test", true)
+
+	defer closeMessengers(messenger1, messenger2, messenger3)
+
+	// connect all peers
+	_ = messenger1.ConnectToPeer(messenger2.Addresses()[0])
+	_ = messenger1.ConnectToPeer(messenger3.Addresses()[0])
+	_ = messenger2.ConnectToPeer(messenger3.Addresses()[0])
+
+	time.Sleep(time.Second)
+
+	err := messenger1.Bootstrap()
+	assert.Nil(t, err)
+
+	err = messenger2.Bootstrap()
+	assert.Nil(t, err)
+
+	err = messenger3.Bootstrap()
+	assert.Nil(t, err)
+
+	time.Sleep(time.Second)
+
+	assert.True(t, messenger1.HasCompatibleProtocolID(messenger2.ID()))
+	assert.True(t, messenger2.HasCompatibleProtocolID(messenger1.ID()))
+
+	assert.False(t, messenger1.HasCompatibleProtocolID(messenger3.ID()))
+	assert.False(t, messenger3.HasCompatibleProtocolID(messenger1.ID()))
+
+	assert.False(t, messenger2.HasCompatibleProtocolID(messenger3.ID()))
+	assert.False(t, messenger3.HasCompatibleProtocolID(messenger2.ID()))
+}

--- a/p2p/libp2p/netMessenger_test.go
+++ b/p2p/libp2p/netMessenger_test.go
@@ -673,7 +673,7 @@ func TestLibp2pMessenger_BroadcastOnChannelBlockingShouldLimitNumberOfGoRoutines
 	for i := 0; i < numBroadcasts; i++ {
 		go func() {
 			err := messenger.BroadcastOnChannelBlocking("test", "test", msg)
-			if err == p2p.ErrTooManyGoroutines {
+			if errors.Is(err, p2p.ErrTooManyGoroutines) {
 				atomic.AddUint32(&numErrors, 1)
 				wg.Done()
 			}
@@ -2369,12 +2369,12 @@ func TestNetworkMessenger_HasCompatibleProtocolID(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	assert.True(t, messenger1.HasCompatibleProtocolID(messenger2.ID()))
-	assert.True(t, messenger2.HasCompatibleProtocolID(messenger1.ID()))
+	assert.True(t, messenger1.HasCompatibleProtocolID(messenger2.Addresses()[0]))
+	assert.True(t, messenger2.HasCompatibleProtocolID(messenger1.Addresses()[0]))
 
-	assert.False(t, messenger1.HasCompatibleProtocolID(messenger3.ID()))
-	assert.False(t, messenger3.HasCompatibleProtocolID(messenger1.ID()))
+	assert.False(t, messenger1.HasCompatibleProtocolID(messenger3.Addresses()[0]))
+	assert.False(t, messenger3.HasCompatibleProtocolID(messenger1.Addresses()[0]))
 
-	assert.False(t, messenger2.HasCompatibleProtocolID(messenger3.ID()))
-	assert.False(t, messenger3.HasCompatibleProtocolID(messenger2.ID()))
+	assert.False(t, messenger2.HasCompatibleProtocolID(messenger3.Addresses()[0]))
+	assert.False(t, messenger3.HasCompatibleProtocolID(messenger2.Addresses()[0]))
 }

--- a/testscommon/connectionsHandlerStub.go
+++ b/testscommon/connectionsHandlerStub.go
@@ -25,7 +25,7 @@ type ConnectionsHandlerStub struct {
 	ThresholdMinConnectedPeersCalled    func() int
 	SetThresholdMinConnectedPeersCalled func(minConnectedPeers int) error
 	SetPeerDenialEvaluatorCalled        func(handler p2p.PeerDenialEvaluator) error
-	HasCompatibleProtocolIDCalled       func(pid core.PeerID) bool
+	HasCompatibleProtocolIDCalled       func(address string) bool
 	CloseCalled                         func() error
 }
 
@@ -157,9 +157,9 @@ func (stub *ConnectionsHandlerStub) SetPeerDenialEvaluator(handler p2p.PeerDenia
 }
 
 // HasCompatibleProtocolID -
-func (stub *ConnectionsHandlerStub) HasCompatibleProtocolID(pid core.PeerID) bool {
+func (stub *ConnectionsHandlerStub) HasCompatibleProtocolID(address string) bool {
 	if stub.HasCompatibleProtocolIDCalled != nil {
-		return stub.HasCompatibleProtocolIDCalled(pid)
+		return stub.HasCompatibleProtocolIDCalled(address)
 	}
 
 	return false

--- a/testscommon/connectionsHandlerStub.go
+++ b/testscommon/connectionsHandlerStub.go
@@ -25,6 +25,7 @@ type ConnectionsHandlerStub struct {
 	ThresholdMinConnectedPeersCalled    func() int
 	SetThresholdMinConnectedPeersCalled func(minConnectedPeers int) error
 	SetPeerDenialEvaluatorCalled        func(handler p2p.PeerDenialEvaluator) error
+	HasCompatibleProtocolIDCalled       func(pid core.PeerID) bool
 	CloseCalled                         func() error
 }
 
@@ -153,6 +154,15 @@ func (stub *ConnectionsHandlerStub) SetPeerDenialEvaluator(handler p2p.PeerDenia
 		return stub.SetPeerDenialEvaluatorCalled(handler)
 	}
 	return nil
+}
+
+// HasCompatibleProtocolID -
+func (stub *ConnectionsHandlerStub) HasCompatibleProtocolID(pid core.PeerID) bool {
+	if stub.HasCompatibleProtocolIDCalled != nil {
+		return stub.HasCompatibleProtocolIDCalled(pid)
+	}
+
+	return false
 }
 
 // Close -


### PR DESCRIPTION
- added functionality that can provide if a provided pid has a compatible protocol ID with the current network messenger instance