### PR TITLE
Fixes and improvments

### DIFF
--- a/websocket/client/client.go
+++ b/websocket/client/client.go
@@ -68,7 +68,7 @@ func NewWebSocketClient(args ArgsWebSocketClient) (*client, error) {
 
 	wsClient := &client{
 		url:                        wsUrl.String(),
-		wsConn:                     connection.NewWSConnClient(),
+		wsConn:                     connection.NewWSConnClient(time.Duration(args.RetryDurationInSeconds) * time.Second),
 		retryDuration:              time.Duration(args.RetryDurationInSeconds) * time.Second,
 		safeCloser:                 closing.NewSafeChanCloser(),
 		transceiver:                wsTransceiver,
@@ -107,32 +107,19 @@ func (c *client) start() {
 				c.log.Warn(fmt.Sprintf("c.openConnection(), retrying in %v...", c.retryDuration), "error", err)
 			}
 
+			if err == nil {
+				closed := c.transceiver.Listen(c.wsConn)
+				if closed {
+					_ = c.wsConn.Close()
+				}
+			}
+
 			timer.Reset(c.retryDuration)
 
 			select {
 			case <-timer.C:
 			case <-c.safeCloser.ChanClose():
 				return
-			}
-		}
-	}()
-
-	go func() {
-		timer := time.NewTimer(c.retryDuration)
-		defer timer.Stop()
-		for {
-			closed := c.transceiver.Listen(c.wsConn)
-			if closed {
-				err := c.wsConn.Close()
-				c.log.Debug("try to close the connection", "close error", err)
-			}
-
-			timer.Reset(c.retryDuration)
-
-			select {
-			case <-c.safeCloser.ChanClose():
-				return
-			case <-timer.C:
 			}
 		}
 	}()

--- a/websocket/connection/wsConnClient.go
+++ b/websocket/connection/wsConnClient.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/multiversx/mx-chain-communication-go/websocket/data"
@@ -13,20 +14,24 @@ import (
 var log = logger.GetOrCreate("connection")
 
 type wsConnClient struct {
-	mut      sync.RWMutex
-	conn     *websocket.Conn
-	clientID string
+	mut          sync.RWMutex
+	conn         *websocket.Conn
+	clientID     string
+	writeTimeout time.Duration
 }
 
 // NewWSConnClient creates a new wrapper over a websocket connection
-func NewWSConnClient() *wsConnClient {
-	return &wsConnClient{}
+func NewWSConnClient(writeTimeout time.Duration) *wsConnClient {
+	return &wsConnClient{
+		writeTimeout: writeTimeout,
+	}
 }
 
 // NewWSConnClientWithConn creates a new wrapper over a provided websocket connection
-func NewWSConnClientWithConn(conn *websocket.Conn) *wsConnClient {
+func NewWSConnClientWithConn(conn *websocket.Conn, writeTimeout time.Duration) *wsConnClient {
 	wsc := &wsConnClient{
-		conn: conn,
+		conn:         conn,
+		writeTimeout: writeTimeout,
 	}
 	wsc.clientID = fmt.Sprintf("%p", wsc)
 
@@ -61,6 +66,17 @@ func (wsc *wsConnClient) ReadMessage() (messageType int, p []byte, err error) {
 	return conn.ReadMessage()
 }
 
+func (wsc *wsConnClient) setWriteDeadline() {
+	if wsc.writeTimeout == 0 {
+		return
+	}
+
+	err := wsc.conn.SetWriteDeadline(time.Now().Add(wsc.writeTimeout))
+	if err != nil {
+		log.Trace("cannot set write deadline", "error", err)
+	}
+}
+
 // WriteMessage calls the underlying write message ws connection func
 func (wsc *wsConnClient) WriteMessage(messageType int, payload []byte) error {
 	wsc.mut.Lock()
@@ -69,6 +85,8 @@ func (wsc *wsConnClient) WriteMessage(messageType int, payload []byte) error {
 	if wsc.conn == nil {
 		return data.ErrConnectionNotOpen
 	}
+
+	wsc.setWriteDeadline()
 
 	return wsc.conn.WriteMessage(messageType, payload)
 }
@@ -110,6 +128,8 @@ func (wsc *wsConnClient) Close() error {
 	}
 
 	log.Debug("closing ws connection...")
+
+	wsc.setWriteDeadline()
 
 	//Cleanly close the connection by sending a close message and then
 	//waiting (with timeout) for the server to close the connection.

--- a/websocket/connection/wsConnClient_test.go
+++ b/websocket/connection/wsConnClient_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/multiversx/mx-chain-communication-go/testscommon"
@@ -39,7 +40,7 @@ func TestWsConnClient_OpenCloseConnectionShouldWork(t *testing.T) {
 	testServer := testscommon.NewHttpTestEchoHandler()
 	defer testServer.Close()
 
-	conClient := NewWSConnClient()
+	conClient := NewWSConnClient(time.Second)
 	connectionURL := createConnectionURLForTestServer(testServer)
 	err := conClient.OpenConnection(connectionURL)
 	require.Nil(t, err)
@@ -54,7 +55,7 @@ func TestWsConnClient_WriteAndReadMessageShouldWork(t *testing.T) {
 	testServer := testscommon.NewHttpTestEchoHandler()
 	defer testServer.Close()
 
-	conClient := NewWSConnClient()
+	conClient := NewWSConnClient(time.Second)
 	connectionURL := createConnectionURLForTestServer(testServer)
 	_ = conClient.OpenConnection(connectionURL)
 	defer func() {
@@ -74,7 +75,7 @@ func TestWsConnClient_WriteAndReadMessageShouldWork(t *testing.T) {
 func TestWsConnClient_WorkingWithANonOpenedConnectionShouldNotPanic(t *testing.T) {
 	t.Parallel()
 
-	conClient := NewWSConnClient()
+	conClient := NewWSConnClient(time.Second)
 	assert.NotPanics(t, func() {
 		err := conClient.Close()
 		assert.Equal(t, data.ErrConnectionNotOpen, err)
@@ -97,7 +98,7 @@ func TestWsConnClient_WorkingWithAClosedConnectionShouldNotPanic(t *testing.T) {
 	testServer := testscommon.NewHttpTestEchoHandler()
 	defer testServer.Close()
 
-	conClient := NewWSConnClient()
+	conClient := NewWSConnClient(time.Second)
 	connectionURL := createConnectionURLForTestServer(testServer)
 	_ = conClient.OpenConnection(connectionURL)
 	_ = conClient.Close()
@@ -124,7 +125,7 @@ func TestWsConnClient_ReOpenConnectionAfterCloseShouldWork(t *testing.T) {
 	testServer := testscommon.NewHttpTestEchoHandler()
 	defer testServer.Close()
 
-	conClient := NewWSConnClient()
+	conClient := NewWSConnClient(time.Second)
 	connectionURL := createConnectionURLForTestServer(testServer)
 	err := conClient.OpenConnection(connectionURL)
 	require.Nil(t, err)
@@ -153,7 +154,7 @@ func TestWsConnClient_ReOpenAlreadyOpenedConnectionShouldError(t *testing.T) {
 	testServer := testscommon.NewHttpTestEchoHandler()
 	defer testServer.Close()
 
-	conClient := NewWSConnClient()
+	conClient := NewWSConnClient(time.Second)
 	connectionURL := createConnectionURLForTestServer(testServer)
 	err := conClient.OpenConnection(connectionURL)
 	require.Nil(t, err)
@@ -168,7 +169,7 @@ func TestWsConnClient_IsOpen(t *testing.T) {
 	testServer := testscommon.NewHttpTestEchoHandler()
 	defer testServer.Close()
 
-	conClient := NewWSConnClient()
+	conClient := NewWSConnClient(time.Second)
 	connectionURL := createConnectionURLForTestServer(testServer)
 	err := conClient.OpenConnection(connectionURL)
 	require.Nil(t, err)
@@ -221,7 +222,7 @@ func TestWsConnClient_CloseWithErrorShouldSetConToNil(t *testing.T) {
 	}
 	require.Nil(t, err)
 
-	conClient := NewWSConnClientWithConn(wsConn)
+	conClient := NewWSConnClientWithConn(wsConn, time.Second)
 	err = conClient.Close()
 	require.Nil(t, err)
 	require.Nil(t, conClient.conn)

--- a/websocket/examples/sendreceive/client/main.go
+++ b/websocket/examples/sendreceive/client/main.go
@@ -16,7 +16,7 @@ import (
 var (
 	marshaller, _ = factory.NewMarshalizer("json")
 	log           = logger.GetOrCreate("client")
-	url           = ":12345"
+	url           = "ws://127.0.0.1:12345"
 )
 
 func main() {
@@ -29,7 +29,7 @@ func main() {
 			WithAcknowledge:            true,
 			BlockingAckOnError:         false,
 			DropMessagesIfNoConnection: false,
-			AcknowledgeTimeoutInSec:    10,
+			AcknowledgeTimeoutInSec:    1,
 		},
 		Marshaller: marshaller,
 		Log:        log,

--- a/websocket/server/server.go
+++ b/websocket/server/server.go
@@ -102,13 +102,18 @@ func (s *server) connectionHandler(connection webSocket.WSConClient) {
 		s.log.Warn("s.SetPayloadHandler cannot set payload handler", "error", err)
 	}
 
+	s.transceiversAndConn.addTransceiverAndConn(webSocketTransceiver, connection)
+
 	go func() {
-		s.transceiversAndConn.addTransceiverAndConn(webSocketTransceiver, connection)
 		// this method is blocking
 		_ = webSocketTransceiver.Listen(connection)
 		s.log.Info("connection closed", "client id", connection.GetID())
 		// if method listen will end, the client was disconnected, and we should remove the listener from the list
 		s.transceiversAndConn.remove(connection.GetID())
+		errC := connection.Close()
+		if errC != nil {
+			s.log.Trace("cannot close connection", "id", connection.GetID(), "error", errC)
+		}
 	}()
 }
 
@@ -136,7 +141,7 @@ func (s *server) initializeServer(wsURL string, wsPath string) {
 			s.log.Warn("could not update websocket connection", "remote address", r.RemoteAddr, "error", errUpgrade)
 			return
 		}
-		client := connection.NewWSConnClientWithConn(ws)
+		client := connection.NewWSConnClientWithConn(ws, s.retryDuration)
 		s.connectionHandler(client)
 	}
 
@@ -210,6 +215,12 @@ func (s *server) Close() error {
 			s.log.Debug("server.Close() cannot close connection", "id", tuple.conn.GetID(), "error", err.Error())
 			lastError = err
 		}
+	}
+
+	err = s.payloadHandler.Close()
+	if err != nil {
+		s.log.Debug("server.Close() cannot close payload handler", "error", err)
+		lastError = err
 	}
 
 	return lastError

--- a/websocket/transceiver/transceiver.go
+++ b/websocket/transceiver/transceiver.go
@@ -2,6 +2,7 @@ package transceiver
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -140,7 +141,11 @@ func (wt *wsTransceiver) verifyPayloadAndSendAckIfNeeded(connection webSocket.WS
 		return
 	}
 
-	err = wt.payloadHandler.ProcessPayload(wsMessage.Payload, wsMessage.Topic, wsMessage.Version)
+	wt.mutPayloadHandler.RLock()
+	handler := wt.payloadHandler
+	wt.mutPayloadHandler.RUnlock()
+
+	err = handler.ProcessPayload(wsMessage.Payload, wsMessage.Topic, wsMessage.Version)
 	if err != nil && wt.blockingAckOnError {
 		wt.log.Warn("wt.payloadHandler.ProcessPayload: cannot handle payload", "error", err)
 		return
@@ -186,6 +191,12 @@ func (wt *wsTransceiver) sendAckIfNeeded(connection webSocket.WSConClient, wsMes
 
 		err := connection.WriteMessage(websocket.BinaryMessage, wsMessageBytes)
 		if err == nil {
+			return
+		}
+
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			wt.log.Error("write deadline exceeded, closing connection", "error", err)
+			_ = connection.Close()
 			return
 		}
 
@@ -267,10 +278,5 @@ func (wt *wsTransceiver) waitForAck(ch chan struct{}) error {
 func (wt *wsTransceiver) Close() error {
 	defer wt.safeCloser.Close()
 
-	err := wt.payloadHandler.Close()
-	if err != nil {
-		wt.log.Debug("cannot close the payload handler", "error", err)
-	}
-
-	return err
+	return nil
 }


### PR DESCRIPTION
- Race fix: Register transceiver before Listen to prevent concurrent map access on the server side.
- Reconnect fix: Merge retry and listen goroutines in the client so Listen only runs after a successful connection open; fix select ordering to not starve the timer.
- Write deadline: Add configurable writeTimeout to websocket client connections; close connection on os.ErrDeadlineExceeded.
- Cleanup: Move payloadHandler.Close() into server's Close() for proper shutdown; close lingering connections when a peer disconnects.